### PR TITLE
Human friendly error when using traffic with stack without domain

### DIFF
--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -269,6 +269,9 @@ def change_version_traffic(stack_ref: StackReference, percentage: float, region)
 
     identifier = version.identifier
 
+    if not version.domain:
+        raise click.UsageError('Stack {} version {} has no domain'.format(version.name, version.version))
+
     domain = version.domain.split('.', 1)[1]
     zone = get_zone(region, domain)
     rr = zone.get_records()


### PR DESCRIPTION
Don't show exception and raise UsageError when trying to change traffic for stack without domain