### PR TITLE
Spilo template: Add mint bucket and refactoring.

### DIFF
--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -7,7 +7,7 @@ from senza.aws import get_security_group
 from senza.components import get_default_zone
 import pystache
 
-from ._helper import prompt, check_security_group, check_s3_bucket
+from ._helper import prompt, check_security_group, check_s3_bucket, get_mint_bucket_name
 
 POSTGRES_PORT = 5432
 HEALTHCHECK_PORT = 8008
@@ -54,6 +54,7 @@ SenzaComponents:
           ETCD_DISCOVERY_URL: "{{discovery_url}}"
           WAL_S3_BUCKET: "{{wal_s3_bucket}}"
         root: True
+        mint_bucket: {{mint_bucket}}
 Resources:
   PostgresRoute53Record:
     Type: AWS::Route53::RecordSet
@@ -73,7 +74,7 @@ Resources:
       HealthCheck:
         HealthyThreshold: 2
         Interval: 5
-        Target: HTTP:{{healthcheck_port}}/pg_master
+        Target: HTTP:{{healthcheck_port}}/master
         Timeout: 3
         UnhealthyThreshold: 2
       Listeners:
@@ -118,6 +119,7 @@ def gather_user_variables(variables, region):
     if (variables['hosted_zone'][-1:] != '.'):
         variables['hosted_zone'] += '.'
     prompt(variables, 'discovery_url', 'ETCD Discovery URL', default='postgres.'+variables['hosted_zone'][:-1])
+    prompt(variables, 'mint_bucket', 'Mint S3 bucket name', default=lambda: get_mint_bucket_name(region))
 
     variables['postgres_port'] = POSTGRES_PORT
     variables['healthcheck_port'] = HEALTHCHECK_PORT


### PR DESCRIPTION
To be able to use the latest Taupage (with berry), we need to specify a mint bucket.
We refactored pg_master into master.