### PR TITLE
Additional configuration options for the postgres template

### DIFF
--- a/senza/components.py
+++ b/senza/components.py
@@ -220,7 +220,8 @@ def component_auto_scaling_group(definition, configuration, args, info, force):
         "Properties": {
             "InstanceType": configuration["InstanceType"],
             "ImageId": {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, configuration["Image"]]},
-            "AssociatePublicIpAddress": configuration.get('AssociatePublicIpAddress', False)
+            "AssociatePublicIpAddress": configuration.get('AssociatePublicIpAddress', False),
+            "EbsOptimized": configuration.get('EbsOptimized', False)
         }
     }
 

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -12,8 +12,7 @@ from ._helper import prompt, check_security_group, check_s3_bucket, get_mint_buc
 POSTGRES_PORT = 5432
 HEALTHCHECK_PORT = 8008
 
-BLOCK_DEVICE_COMPONENT=1
-COMPONENTS = ['''
+TEMPLATE = '''
 # basic information for generating and executing this definition
 SenzaInfo:
   StackName: spilo
@@ -35,12 +34,18 @@ SenzaComponents:
         Minimum: 3
         Maximum: 3
         MetricType: CPU
-      InstanceType: {{instance_type}}''','''
+      InstanceType: {{instance_type}}
       BlockDeviceMappings:
         - DeviceName: /dev/xvdk
           Ebs:
             VolumeSize: {{volume_size}}
-            VolumeType: {{volume_type}}''','''
+            VolumeType: {{volume_type}}
+            {{#snapshot_id}}
+            SnapshotId: {{snapshot_id}}
+            {{/snapshot_id}}
+            {{#volume_iops}}
+            Iops: {{volume_iops}}
+            {{/volume_iops}}
       ElasticLoadBalancer: PostgresLoadBalancer
       HealthCheckType: EC2
       LoadBalancerNames:
@@ -67,6 +72,9 @@ SenzaComponents:
             erase_on_boot: true
             options: {{fsoptions}}
         mint_bucket: {{mint_bucket}}
+        {{#scalyr_account_key}}
+        scalyr_account_key: {{scalyr_account_key}}
+        {{/scalyr_account_key}}
 Resources:
   PostgresRoute53Record:
     Type: AWS::Route53::RecordSet
@@ -121,7 +129,7 @@ Resources:
           - Effect: Allow
             Action: "s3:*"
             Resource: "*"
-''']
+'''
 
 
 def gather_user_variables(variables, region):
@@ -130,28 +138,28 @@ def gather_user_variables(variables, region):
     prompt(variables, 'hosted_zone', 'Hosted Zone', default=get_default_zone(region) or 'example.com')
     if (variables['hosted_zone'][-1:] != '.'):
         variables['hosted_zone'] += '.'
-    prompt(variables, 'discovery_url', 'ETCD Discovery URL', default='postgres.'+variables['hosted_zone'][:-1])
+    prompt(variables, 'discovery_url', 'ETCD Discovery URL',
+           default='postgres.'+variables['hosted_zone'][:-1])
     prompt(variables, 'volume_size', 'Database volume size (GB, 10 or more)', default=10)
     prompt(variables, 'volume_type', 'Database volume type (gp2, io1 or standard)', default='gp2')
     if variables['volume_type'] == 'io1':
-      pio_max = variables['volume_size'] * 30
-      prompt(variables, "volume_iops", 'Provisioned I/O operations per second (100 - {0})'.format(pio_max), default=str(int(pio_max/2)))
-      COMPONENTS[BLOCK_DEVICE_COMPONENT] += '''
-            Iops: {{volume_iops}}'''
+        pio_max = variables['volume_size'] * 30
+        prompt(variables, "volume_iops", 'Provisioned I/O operations per second (100 - {0})'.format(pio_max),
+               default=str(int(pio_max/2)))
     prompt(variables, "snapshot_id", "ID of the snapshot to populate EBS volume from", default="")
-    if variables['snapshot_id']:
-      COMPONENTS[BLOCK_DEVICE_COMPONENT] += '''
-            SnapshotId: {{snapshot_id}}'''
     prompt(variables, "fstype", "Filesystem for the data partition", default="ext4")
-    prompt(variables, "fsoptions", "Filesystem mount options (comma-separated)", default="noatime,nodiratime,nobarrier")
+    prompt(variables, "fsoptions", "Filesystem mount options (comma-separated)",
+           default="noatime,nodiratime,nobarrier")
     prompt(variables, 'mint_bucket', 'Mint S3 bucket name', default=lambda: get_mint_bucket_name(region))
+    prompt(variables, "scalyr_account_key", "Account key for your scalyr account", "")
 
     variables['postgres_port'] = POSTGRES_PORT
     variables['healthcheck_port'] = HEALTHCHECK_PORT
 
     sg_name = 'app-spilo'
     variables['spilo_sg_id'] = get_security_group(region, sg_name).id
-    rules_missing = check_security_group(sg_name, [('tcp', 22), ('tcp', POSTGRES_PORT), ('tcp', HEALTHCHECK_PORT)],
+    rules_missing = check_security_group(sg_name,
+                                         [('tcp', 22), ('tcp', POSTGRES_PORT), ('tcp', HEALTHCHECK_PORT)],
                                          region, allow_from_self=True)
 
     if ('tcp', 22) in rules_missing:
@@ -174,6 +182,5 @@ def gather_user_variables(variables, region):
 
 
 def generate_definition(variables):
-    TEMPLATE = ''.join(COMPONENTS)
     definition_yaml = pystache.render(TEMPLATE, variables)
     return definition_yaml

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -35,6 +35,7 @@ SenzaComponents:
         Maximum: 3
         MetricType: CPU
       InstanceType: {{instance_type}}
+      EbsOptimized: True
       BlockDeviceMappings:
         - DeviceName: /dev/xvdk
           Ebs:


### PR DESCRIPTION
Add an ability to configure filesystem type, options, provisioned IO requests for the IO1 EBS volumes, as well as optional scalyr account credentials. In addition, allow EbsOptimized flag in the senza autoscaling group template and use it always for PostgreSQL instances.

Trim extra long lines in postgres template.