### PR TITLE
Fine-grained permissions for spilo app.

### DIFF
--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -7,8 +7,7 @@ from senza.aws import get_security_group
 from senza.components import get_default_zone
 import pystache
 
-from ._helper import prompt, check_security_group, check_s3_bucket,\
-                     get_mint_bucket_name, get_account_id
+from ._helper import prompt, check_security_group, check_s3_bucket, get_mint_bucket_name
 
 POSTGRES_PORT = 5432
 HEALTHCHECK_PORT = 8008

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -7,7 +7,8 @@ from senza.aws import get_security_group
 from senza.components import get_default_zone
 import pystache
 
-from ._helper import prompt, check_security_group, check_s3_bucket, get_mint_bucket_name
+from ._helper import prompt, check_security_group, check_s3_bucket,\
+                     get_mint_bucket_name, get_account_id
 
 POSTGRES_PORT = 5432
 HEALTHCHECK_PORT = 8008
@@ -56,7 +57,7 @@ SenzaComponents:
       SecurityGroups:
         - app-spilo
       IamRoles:
-        - Ref: PostgresS3AccessRole
+        - Ref: PostgresAccessRole
       TaupageConfig:
         runtime: Docker
         source: "{{=<% %>=}}{{Arguments.ImageVersion}}<%={{ }}=%>"
@@ -113,7 +114,7 @@ Resources:
           - LoadBalancerSubnets
           - Ref: AWS::Region
           - Subnets
-  PostgresS3AccessRole:
+  PostgresAccessRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -125,12 +126,25 @@ Resources:
           Action: sts:AssumeRole
       Path: /
       Policies:
-      - PolicyName: AmazonEC2ReadOnlyAccess
+      - PolicyName: SpiloEC2S3Access
         PolicyDocument:
           Version: "2012-10-17"
           Statement:
           - Effect: Allow
-            Action: "s3:*"
+            Action: s3:*
+            Resource:
+              - arn:aws:s3:::{{wal_s3_bucket}}/spilo/*
+              - arn:aws:s3:::{{wal_s3_bucket}}
+          - Effect: Allow
+            Action: s3:GetObject
+            Resource:
+              - arn:aws:s3:::{{mint_bucket}}/spilo/*
+              - arn:aws:s3:::{{mint_bucket}}
+          - Effect: Allow
+            Action: ec2:CreateTags
+            Resource: "*"
+          - Effect: Allow
+            Action: ec2:Describe*
             Resource: "*"
 '''
 


### PR DESCRIPTION
- Allow S3 access for read to mint bucket
- Allow full S3 access for WAL-E bucket
- Allow setting tags on EC2 objects
- Allow browsing EC2 objects

The latter 2 actions doesn't seem to support specific
resources, so we set it for *.