### PR TITLE
add AssociatePublicIpAddress as a parameter for all stack types

### DIFF
--- a/senza/templates/bgapp.py
+++ b/senza/templates/bgapp.py
@@ -29,6 +29,7 @@ SenzaComponents:
         - app-{{application_id}}
       IamRoles:
         - app-{{application_id}}
+      AssociatePublicIpAddress: false # change for standalone deployment in default VPC
       TaupageConfig:
         application_version: "{{=<% %>=}}{{Arguments.ImageVersion}}<%={{ }}=%>"
         runtime: Docker

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -57,6 +57,7 @@ SenzaComponents:
         - app-spilo
       IamRoles:
         - Ref: PostgresAccessRole
+      AssociatePublicIpAddress: false # change for standalone deployment in default VPC
       TaupageConfig:
         runtime: Docker
         source: "{{=<% %>=}}{{Arguments.ImageVersion}}<%={{ }}=%>"


### PR DESCRIPTION
I want to be able to use senza without zalando-style accounts/vpc's. With AssociatePublicIpAddress as a default value one is able to see what to change in the yml file to do so.