### PR TITLE
Handle keyword parameters in create and print cmds

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -293,7 +293,7 @@ def parse_args(input, region, version, parameter):
     for key, value in paras.items():
         if value is None:  # TODO: and no default value
             raise click.UsageError('Missing parameter ""'.format(key))
-            
+
     args = TemplateArguments(region=region, version=version, **paras)
     return args
 

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -257,11 +257,43 @@ def is_credentials_expired_error(e: BotoServerError) -> bool:
 
 def parse_args(input, region, version, parameter):
     paras = {}
+
+    # process positional parameters first
+    seen_keyword = False
     for i, param in enumerate(input['SenzaInfo'].get('Parameters', [])):
         for key, config in param.items():
-            if len(parameter) <= i:
-                raise click.UsageError('Missing parameter "{}"'.format(key))
-            paras[key] = parameter[i]
+            paras[key] = None  # collect all allowed keys regardless
+            if i < len(parameter):
+                if '=' in parameter[i]:
+                    seen_keyword = True
+                else:
+                    if seen_keyword:
+                        raise click.UsageError("Positional parameters must not follow keywords.")
+                    paras[key] = parameter[i]
+            else:
+                if not seen_keyword:
+                    raise click.UsageError('Missing parameter "{}"'.format(key))
+
+    if len(paras) < len(parameter):
+        raise click.UsageError('Too many parameters given.')
+
+    # process keyword parameters separately, if any
+    if seen_keyword:
+        for i in range(len(parameter)):
+            param = parameter[i]
+            if '=' in param:
+                key, value = param.split('=', 1)  # split only on first =
+                if key not in paras:
+                    raise click.UsageError('Unrecognized keyword parameter: "{}"'.format(key))
+                if paras[key] is not None:
+                    raise click.UsageError('Parameter specified multiple times: "{}"'.format(key))
+                paras[key] = value
+
+    # finally, make sure every parameter got a value assigned
+    for key, value in paras.items():
+        if value is None:  # TODO: and no default value
+            raise click.UsageError('Missing parameter ""'.format(key))
+            
     args = TemplateArguments(region=region, version=version, **paras)
     return args
 

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -292,7 +292,7 @@ def parse_args(input, region, version, parameter):
     # finally, make sure every parameter got a value assigned
     for key, value in paras.items():
         if value is None:  # TODO: and no default value
-            raise click.UsageError('Missing parameter ""'.format(key))
+            raise click.UsageError('Missing parameter "{}"'.format(key))
 
     args = TemplateArguments(region=region, version=version, **paras)
     return args

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ def test_print_basic(monkeypatch):
         with open('myapp.yaml', 'w') as fd:
             yaml.dump(data, fd)
 
-        result = runner.invoke(cli, ['print', 'myapp.yaml', '--region=myregion', '123', '1.0-SNAPSHOT'],
+        result = runner.invoke(cli, ['print', 'myapp.yaml', '--region=myregion', '123'],
                                catch_exceptions=False)
 
     assert 'AWSTemplateFormatVersion' in result.output
@@ -490,30 +490,58 @@ def test_create(monkeypatch):
     runner = CliRunner()
     data = {'SenzaComponents': [{'Config': {'Type': 'Senza::Configuration'}}],
             'SenzaInfo': {'OperatorTopicId': 'my-topic',
-                          'Parameters': [{'MyParam': {'Type': 'String'}}],
+                          'Parameters': [{'MyParam': {'Type': 'String'}}, {'ExtraParam': {'Type': 'String'}}],
                           'StackName': 'test'}}
 
     with runner.isolated_filesystem():
         with open('myapp.yaml', 'w') as fd:
             yaml.dump(data, fd)
 
-        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '1', 'my-param-value'],
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '1', 'my-param-value', 'extra-param-value'],
                                catch_exceptions=False)
         assert 'DRY-RUN' in result.output
 
-        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', '1', 'my-param-value'],
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', '1', 'my-param-value', 'extra-param-value'],
                                catch_exceptions=False)
         assert 'OK' in result.output
 
         cf.create_stack.side_effect = boto.exception.BotoServerError('sdf', 'already exists',
                                                                      {'Error': {'Code': 'AlreadyExistsException'}})
-        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', '1', 'my-param-value'],
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', '1', 'my-param-value', 'extra-param-value'],
                                catch_exceptions=True)
         assert 'Stack test-1 already exists' in result.output
 
-        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', 'abcde'*25, 'my-param-value'],
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--region=myregion', 'abcde'*25, 'my-param-value', 'extra-param-value'],
                                catch_exceptions=True)
         assert 'cannot exceed 128 characters.  Please choose another name/version.' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2'],
+                               catch_exceptions=True)
+        assert 'Missing parameter' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'my-param-value', 'ExtraParam=extra-param-value'],
+                               catch_exceptions=True)
+        assert 'OK' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'my-param-value', 'ExtraParam=extra=param=value'],  # checks that equal signs are OK in the keyword param value
+                               catch_exceptions=True)
+        assert 'OK' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'UnknownParam=value'],
+                               catch_exceptions=True)
+        assert 'Unrecognized keyword parameter' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'my-param-value', 'MyParam=param-value-again'],
+                               catch_exceptions=True)
+        assert 'Parameter specified multiple times' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'MyParam=my-param-value', 'MyParam=param-value-again'],
+                               catch_exceptions=True)
+        assert 'Parameter specified multiple times' in result.output
+
+        result = runner.invoke(cli, ['create', 'myapp.yaml', '--dry-run', '--region=myregion', '2', 'MyParam=my-param-value', 'positional'],
+                               catch_exceptions=True)
+        assert 'Positional parameters must not follow keywords' in result.output
 
 
 def test_traffic(monkeypatch):


### PR DESCRIPTION
Positional and keyword parameters can be used together, much like
in Python.  A positional parameter must not follow one specified
with a keyword.

This also checks that no parameters is specified more than once
(either as positional or keyword) and that every parameter is
assigned a value.  Adding default parameter values should be easy
with this in place.