### PR TITLE
Add the ability to provide custom tags to all resources of the Cloud …

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -417,11 +417,16 @@ def create(definition, region, version, parameter, disable_rollback, dry_run, fo
     for name, parameter in data.get("Parameters", {}).items():
         parameters.append([name, getattr(args, name, None)])
 
-    tags = {
+    tags = {}
+    for tag in input["SenzaInfo"].get('Tags', ()):
+        for key, value in tag.items():
+            tags[key] = evaluate_template(value, info, [], args)
+
+    tags.update( {
         "Name": stack_name,
         "StackName": input["SenzaInfo"]["StackName"],
         "StackVersion": version
-    }
+    } )
 
     if "OperatorTopicId" in input["SenzaInfo"]:
         topic = input["SenzaInfo"]["OperatorTopicId"]

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -422,11 +422,11 @@ def create(definition, region, version, parameter, disable_rollback, dry_run, fo
         for key, value in tag.items():
             tags[key] = evaluate_template(value, info, [], args)
 
-    tags.update( {
+    tags.update({
         "Name": stack_name,
         "StackName": input["SenzaInfo"]["StackName"],
         "StackVersion": version
-    } )
+    })
 
     if "OperatorTopicId" in input["SenzaInfo"]:
         topic = input["SenzaInfo"]["OperatorTopicId"]

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -418,8 +418,9 @@ def create(definition, region, version, parameter, disable_rollback, dry_run, fo
         parameters.append([name, getattr(args, name, None)])
 
     tags = {}
-    for tag in input["SenzaInfo"].get('Tags', ()):
+    for tag in input["SenzaInfo"].get('Tags', []):
         for key, value in tag.items():
+            # # As the SenzaInfo is not evaluated, we explicitly evaluate the values here
             tags[key] = evaluate_template(value, info, [], args)
 
     tags.update({

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -24,6 +24,8 @@ SenzaInfo:
     - ImageVersion:
         Description: "Docker image version of spilo."
   {{/docker_image}}
+  Tags:
+    - SpiloCluster: "{{=<% %>=}}{{Arguments.version}}<%={{ }}=%>"
 
 # a list of senza components to apply to the definition
 SenzaComponents:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -491,7 +491,7 @@ def test_create(monkeypatch):
     data = {'SenzaComponents': [{'Config': {'Type': 'Senza::Configuration'}}],
             'SenzaInfo': {'OperatorTopicId': 'my-topic',
                           'Parameters': [{'MyParam': {'Type': 'String'}}, {'ExtraParam': {'Type': 'String'}}, {'DefParam': {'Type': 'String', 'DefaultValue': 'DefValue'}}],
-                          'StackName': 'test'}}
+                          'StackName': 'test', 'Tags': [{'CustomTag': 'CustomValue'}]}}
 
     with runner.isolated_filesystem():
         with open('myapp.yaml', 'w') as fd:


### PR DESCRIPTION
…Formation stack.

To enable discovery of resources in aws we want to use tags to aid in finding our components.
The StackName will differ quite a lot between teams, as it is probably unique within 1 organization.

This patch adds the ability to provide a list of additional tags to be applied to all the resources.