### PR TITLE
Fixed default parameter values

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -267,7 +267,7 @@ def parse_args(input, region, version, parameter):
         for key, config in param.items():
             # collect all allowed keys and default values regardless
             paras[key] = None
-            defaults[key] = config.get('DefaultValue', None)
+            defaults[key] = config.get('Default', None)
             if i < len(parameter):
                 if '=' in parameter[i]:
                     seen_keyword = True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -490,7 +490,7 @@ def test_create(monkeypatch):
     runner = CliRunner()
     data = {'SenzaComponents': [{'Config': {'Type': 'Senza::Configuration'}}],
             'SenzaInfo': {'OperatorTopicId': 'my-topic',
-                          'Parameters': [{'MyParam': {'Type': 'String'}}, {'ExtraParam': {'Type': 'String'}}, {'DefParam': {'Type': 'String', 'DefaultValue': 'DefValue'}}],
+                          'Parameters': [{'MyParam': {'Type': 'String'}}, {'ExtraParam': {'Type': 'String'}}, {'DefParam': {'Type': 'String', 'Default': 'DefValue'}}],
                           'StackName': 'test', 'Tags': [{'CustomTag': 'CustomValue'}]}}
 
     with runner.isolated_filesystem():


### PR DESCRIPTION
CloudFormation templates were being created with `DefaultValue` instead of `Default` resulting in

    {"Error":{"Code":"ValidationError","Message":"Invalid template parameter property 'DefaultValue'","Type":"Sender"},"RequestId":"..."}

I don't think anyone was using the DefaultValue feature or they would be getting the same CF errors. For this reason the quickest and easiest fix is just to rename the Senza syntax to use `Default`.
