### PR TITLE
Postgres template: revert 02160a673b45c95536bbd73333261bc078ad56de

### DIFF
--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -6,7 +6,7 @@ import click
 from clickclick import warning, error
 from senza.aws import get_security_group
 from senza.components.weighted_dns_elastic_load_balancer import get_default_zone
-from senza.utils import pystache_render
+import pystache
 import requests
 
 from ._helper import prompt, check_security_group, check_s3_bucket
@@ -230,7 +230,7 @@ def gather_user_variables(variables, region):
 
 
 def generate_definition(variables):
-    definition_yaml = pystache_render(TEMPLATE, variables)
+    definition_yaml = pystache.render(TEMPLATE, variables)
     return definition_yaml
 
 


### PR DESCRIPTION
The template for the PostgreSQL appliance (Spilo) uses features of Mustache that are incompatible
with strict keychecking and therefore cannot be forced to have all keys specified.
- Sections
- Inverted Sections