### PR TITLE
Increase the timeout for ELB's serving Spilo.

### DIFF
--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -123,6 +123,8 @@ Resources:
           LoadBalancerPort: 5432
           Protocol: TCP
       LoadBalancerName: "spilo-{{=<% %>=}}{{Arguments.version}}<%={{ }}=%>"
+      ConnectionSettings:
+        IdleTimeout: 3600
       SecurityGroups:
         - {{spilo_sg_id}}
       Scheme: internal


### PR DESCRIPTION
Some usage of Spilo does not keep the connection alive, for example interactively querying using psql.
The default timeout of 60 seconds is not adequate for these usecases.

Fixes some occurces of https://github.com/zalando/spilo/issues/25