### PR TITLE
Fix crashing "senza list --all"

### DIFF
--- a/senza/aws.py
+++ b/senza/aws.py
@@ -134,7 +134,7 @@ def get_stacks(stack_refs: list, region, all=False):
     # boto3.resource('cf')-stacks.filter() doesn't support status_filter, only StackName
     cf = boto3.client('cloudformation', region)
     if all:
-        status_filter = None
+        status_filter = []
     else:
         # status_filter = [st for st in cf.valid_states if st != 'DELETE_COMPLETE']
         status_filter = [


### PR DESCRIPTION
Providing `None` as filter results in exception:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter StackStatusFilter, value: None, type: <class 'NoneType'>, valid types: <class 'list'>, <class 'tuple'>
```
