### PR TITLE
Allow AWS functions and Ref in TaupageConfig

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -259,12 +259,7 @@ def test_component_taupage_auto_scaling_group_user_data_without_ref():
         }
     }
 
-    expected_user_data = {
-        'Fn::Join': ['', [
-            '#taupage-ami-config\nenvironment:\n  ENV1: ', {'Fn::GetAtt': ['Obj2', 'Attr2']},
-            '\n  ENV2: ', {'Ref': 'REF2'}, '\n  ENV3: r3\nmint_bucket: ', {'Ref': 'REF1'},
-            '\nruntime: Docker\nsource: ', {'Fn::Join': ['/', ['pierone.stups.zalan.do', 'cool',
-                                                         {'Fn::GetAtt': ['Obj1', 'Attr1']}]]}, '\n']]}
+    expected_user_data = '#taupage-ami-config\nenvironment:\n  ENV3: r3\nruntime: Docker\n'
 
     assert expected_user_data == generate_user_data(configuration)
 


### PR DESCRIPTION
This PR solves the issue #46

It allows to put any valid Fn::* in UserData and Ref in the TaupageConfig property of a Senza::TaupageAutoScalingGroup.

Something like that:
```yaml
SenzaComponents:
  - Exhibitor:
      Type: Senza::TaupageAutoScalingGroup
      TaupageConfig:
        environment:
          S3_BUCKET: {Ref: "ExhibitorBucket"}
          S3_PREFIX: "exhibitor"
Resources:
  ExhibitorBucket:
      Type: AWS::S3::Bucket
```
will expand into:
```json
{"UserData": {"Fn::Base64": {"Fn::Join": ["", [
  "#taupage-ami-config\nenvironment:\n  S3_BUCKET: ",
  {"Ref": "ExhibitorBucket"},
  "\n  S3_PREFIX: exhibitor\n"]]}}}
```
It first transforms the configuration tree so the nodes representing *Ref* or *Fn::* are transformed into a template string such as *{{ json }}*, where *json* is the JSON representation of the AWS function.
Then it is dumped into a string by the *yaml.dump* function. Once we have an string with the special template entries in it, it is iterated to extract fixed strings and AWS functions and compose them in a *Fn::Join*. The *Fn::Join* is **only used** if required, otherwise it just generated an string as it was done before.