### PR TITLE
#140 enable ELB connection draining by default (60s)

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -128,6 +128,10 @@ def component_elastic_load_balancer(definition, configuration, args, info, force
                     "LoadBalancerPort": 443
                 }
             ],
+            "ConnectionDrainingPolicy": {
+                "Enabled": True,
+                "Timeout": 60
+            },
             "CrossZone": "true",
             "LoadBalancerName": loadbalancer_name,
             "SecurityGroups": resolve_security_groups(configuration["SecurityGroups"], args.region),


### PR DESCRIPTION
Set connection draining to 60s by default (can be overwritten in Senza definition!)