### PR TITLE
Use region in traffic.inform_sns

### DIFF
--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -378,6 +378,6 @@ def change_version_traffic(stack_ref: StackReference, percentage: float, region)
 def inform_sns(arns: list, message: str, region):
     jsonizer = JSONEncoder()
     sns_topics = set(arns)
-    sns = boto3.client('sns')
+    sns = boto3.client('sns', region_name=region)
     for sns_topic in sns_topics:
         sns.publish(TopicArn=sns_topic, Subject="SenzaTrafficRedirect", Message=jsonizer.encode((message)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -623,7 +623,7 @@ def test_console(monkeypatch):
             return ec2
         return MagicMock()
 
-    def my_client(rtype, *args):
+    def my_client(rtype, *args, **kwargs):
         if rtype == 'cloudformation':
             cf = MagicMock()
             cf.list_stacks.return_value = {'StackSummaries': [{'StackName': 'test-1'}]}
@@ -1105,7 +1105,7 @@ def test_traffic(monkeypatch):
     def my_resource(rtype, *args):
         return MagicMock()
 
-    def my_client(rtype, *args):
+    def my_client(rtype, *args, **kwargs):
         if rtype == 'route53':
             return route53
         return MagicMock()


### PR DESCRIPTION
`traffic.inform_sns` was receiving a `region` but not using it for anything. This caused the error seen in zalando/lizzy#24.