### PR TITLE
Feature/postgres encrypt values

### DIFF
--- a/senza/aws.py
+++ b/senza/aws.py
@@ -3,6 +3,7 @@ import datetime
 import functools
 import time
 import boto3
+import base64
 from botocore.exceptions import ClientError
 
 
@@ -24,9 +25,13 @@ def get_security_group(region: str, sg_name: str):
             raise
 
 
-def encrypt(region: str, KeyId: str, Plaintext: str):
+def encrypt(region: str, KeyId: str, Plaintext: str, encode=False):
     kms = boto3.client('kms', region)
-    return kms.encrypt(KeyId=KeyId, Plaintext=Plaintext)['CiphertextBlob']
+    encrypted = kms.encrypt(KeyId=KeyId, Plaintext=Plaintext)['CiphertextBlob']
+    if encode:
+        return base64.b64encode(encrypted).decode('utf-8')
+
+    return encrypted
 
 
 def list_kms_keys(region: str, describe=False):

--- a/senza/aws.py
+++ b/senza/aws.py
@@ -28,7 +28,7 @@ def get_security_group(region: str, sg_name: str):
 def encrypt(region: str, KeyId: str, Plaintext: str, b64encode=False):
     kms = boto3.client('kms', region)
     encrypted = kms.encrypt(KeyId=KeyId, Plaintext=Plaintext)['CiphertextBlob']
-    if encode:
+    if b64encode:
         return base64.b64encode(encrypted).decode('utf-8')
 
     return encrypted

--- a/senza/aws.py
+++ b/senza/aws.py
@@ -24,6 +24,20 @@ def get_security_group(region: str, sg_name: str):
             raise
 
 
+def encrypt(region: str, KeyId: str, Plaintext: str):
+    kms = boto3.client('kms', region)
+    return kms.encrypt(KeyId=KeyId, Plaintext=Plaintext)['CiphertextBlob']
+
+
+def list_kms_keys(region: str, describe=False):
+    kms = boto3.client('kms', region)
+    keys = list(kms.list_keys()['Keys'])
+    if describe:
+        for key in keys:
+            key.update(kms.describe_key(KeyId=key['KeyId'])['KeyMetadata'])
+    return keys
+
+
 def resolve_security_groups(security_groups: list, region: str):
     result = []
     for security_group in security_groups:

--- a/senza/aws.py
+++ b/senza/aws.py
@@ -25,7 +25,7 @@ def get_security_group(region: str, sg_name: str):
             raise
 
 
-def encrypt(region: str, KeyId: str, Plaintext: str, encode=False):
+def encrypt(region: str, KeyId: str, Plaintext: str, b64encode=False):
     kms = boto3.client('kms', region)
     encrypted = kms.encrypt(KeyId=KeyId, Plaintext=Plaintext)['CiphertextBlob']
     if encode:
@@ -34,12 +34,16 @@ def encrypt(region: str, KeyId: str, Plaintext: str, encode=False):
     return encrypted
 
 
-def list_kms_keys(region: str, describe=False):
+def list_kms_keys(region: str, details=True):
     kms = boto3.client('kms', region)
     keys = list(kms.list_keys()['Keys'])
-    if describe:
+    if details:
+        aliases = kms.list_aliases()['Aliases']
+
         for key in keys:
+            key['aliases'] = [a['AliasName'] for a in aliases if a.get('TargetKeyId') == key['KeyId']]
             key.update(kms.describe_key(KeyId=key['KeyId'])['KeyMetadata'])
+
     return keys
 
 

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -65,7 +65,9 @@ SenzaComponents:
           {{/use_ebs}}
       ElasticLoadBalancer:
         - PostgresLoadBalancer
+        {{#add_replica_loadbalancer}}
         - PostgresReplicaLoadBalancer
+        {{/add_replica_loadbalancer}}
       HealthCheckType: EC2
       SecurityGroups:
         - app-spilo
@@ -102,6 +104,7 @@ SenzaComponents:
         scalyr_account_key: {{scalyr_account_key}}
         {{/scalyr_account_key}}
 Resources:
+  {{#add_replica_loadbalancer}}
   PostgresReplicaRoute53Record:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -112,17 +115,6 @@ Resources:
       ResourceRecords:
         - Fn::GetAtt:
            - PostgresReplicaLoadBalancer
-           - DNSName
-  PostgresRoute53Record:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      Type: CNAME
-      TTL: 20
-      HostedZoneName: {{hosted_zone}}
-      Name: "{{=<% %>=}}{{Arguments.version}}<%={{ }}=%>.{{hosted_zone}}"
-      ResourceRecords:
-        - Fn::GetAtt:
-           - PostgresLoadBalancer
            - DNSName
   PostgresReplicaLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
@@ -149,6 +141,18 @@ Resources:
           - LoadBalancerSubnets
           - Ref: AWS::Region
           - Subnets
+  {{/add_replica_loadbalancer}}
+  PostgresRoute53Record:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Type: CNAME
+      TTL: 20
+      HostedZoneName: {{hosted_zone}}
+      Name: "{{=<% %>=}}{{Arguments.version}}<%={{ }}=%>.{{hosted_zone}}"
+      ResourceRecords:
+        - Fn::GetAtt:
+           - PostgresLoadBalancer
+           - DNSName
   PostgresLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -224,6 +228,7 @@ def gather_user_variables(variables, region, account_info):
            default='{}-{}-spilo-app'.format(get_account_alias(), region))
     prompt(variables, 'instance_type', 'EC2 instance type', default='t2.micro')
     variables['hosted_zone'] = account_info.Domain or 'example.com'
+    variables['add_replica_loadbalancer'] = click.confirm('Do you want a replica ELB?', default=False)
     if (variables['hosted_zone'][-1:] != '.'):
         variables['hosted_zone'] += '.'
     prompt(variables, 'discovery_domain', 'ETCD Discovery Domain',

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -213,6 +213,12 @@ Resources:
 
 def ebs_optimized_supported(instance_type):
     # per http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
+    """
+    >>> ebs_optimized_supported('c3.xlarge')
+    True
+    >>> ebs_optimized_supported('t2.micro')
+    False
+    """
     return instance_type in ('c1.large', 'c3.xlarge', 'c3.2xlarge', 'c3.4xlarge',
                              'c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge', 'c4.8xlarge',
                              'd2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge',
@@ -337,8 +343,12 @@ def gather_user_variables(variables, region, account_info):
     return variables
 
 
-def generate_random_password():
-    return ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(64))
+def generate_random_password(length=64):
+    """
+    >>> len(generate_random_password(61))
+    61
+    """
+    return ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(length))
 
 
 def generate_definition(variables):

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -222,30 +222,59 @@ def ebs_optimized_supported(instance_type):
                              'r3.4xlarge')
 
 
+def set_default_variables(variables):
+    variables.setdefault('discovery_domain', 'postgres.example.com')
+    variables.setdefault('docker_image', None)
+    variables.setdefault('ebs_optimized', None)
+    variables.setdefault('fsoptions','noatime,nodiratime,nobarrier')
+    variables.setdefault('fstype', 'ext4')
+    variables.setdefault('healthcheck_port', HEALTHCHECK_PORT)
+    variables.setdefault('hosted_zone', 'example.com')
+    variables.setdefault('instance_type', 't2.micro')
+    variables.setdefault('kms_arn', None)
+    variables.setdefault('pgpassword_admin', 'admin')
+    variables.setdefault('pgpassword_standby', 'standby')
+    variables.setdefault('pgpassword_superuser', 'zalando')
+    variables.setdefault('postgres_port', POSTGRES_PORT)
+    variables.setdefault('scalyr_account_key', None)
+    variables.setdefault('snapshot_id', None)
+    variables.setdefault('spilo_sg_id', None)
+    variables.setdefault('use_ebs', True)
+    variables.setdefault('volume_iops', 300)
+    variables.setdefault('volume_size', 10)
+    variables.setdefault('volume_type', 'gp2')
+    variables.setdefault('wal_s3_bucket', None)
+
+    return variables
+
+
 def gather_user_variables(variables, region, account_info):
+    defaults = set_default_variables(dict())
+
     if click.confirm('Do you want to set the docker image now? [No]'):
         prompt(variables, "docker_image", "Docker Image Version", default=get_latest_spilo_image())
-    else:
-        variables['docker_image'] = None
+
     prompt(variables, 'wal_s3_bucket', 'Postgres WAL S3 bucket to use',
            default='{}-{}-spilo-app'.format(get_account_alias(), region))
+
     prompt(variables, 'instance_type', 'EC2 instance type', default='t2.micro')
-    variables['hosted_zone'] = account_info.Domain or 'example.com'
+
+    variables['hosted_zone'] = account_info.Domain or defaults['hosted_zone']
     if (variables['hosted_zone'][-1:] != '.'):
         variables['hosted_zone'] += '.'
     prompt(variables, 'discovery_domain', 'ETCD Discovery Domain',
            default='postgres.' + variables['hosted_zone'][:-1])
+
     if variables['instance_type'].lower().split('.')[0] in ('c3', 'g2', 'hi1', 'i2', 'm3', 'r3'):
         variables['use_ebs'] = click.confirm('Do you want database data directory on external (EBS) storage? [Yes]',
-                                             default=True)
+                                             default=defaults['use_ebs'])
     else:
         variables['use_ebs'] = True
-    variables['ebs_optimized'] = None
-    variables['volume_iops'] = None
-    variables['snapshot_id'] = None
+
     if variables['use_ebs']:
-        prompt(variables, 'volume_size', 'Database volume size (GB, 10 or more)', default=10)
-        prompt(variables, 'volume_type', 'Database volume type (gp2, io1 or standard)', default='gp2')
+        prompt(variables, 'volume_size', 'Database volume size (GB, 10 or more)', default=defaults['volume_size'])
+        prompt(variables, 'volume_type', 'Database volume type (gp2, io1 or standard)',
+               default=defaults['volume_type'])
         if variables['volume_type'] == 'io1':
             pio_max = variables['volume_size'] * 30
             prompt(variables, "volume_iops", 'Provisioned I/O operations per second (100 - {0})'.
@@ -253,9 +282,9 @@ def gather_user_variables(variables, region, account_info):
         prompt(variables, "snapshot_id", "ID of the snapshot to populate EBS volume from", default="")
         if ebs_optimized_supported(variables['instance_type']):
             variables['ebs_optimized'] = True
-    prompt(variables, "fstype", "Filesystem for the data partition", default="ext4")
+    prompt(variables, "fstype", "Filesystem for the data partition", default=defaults['fstype'])
     prompt(variables, "fsoptions", "Filesystem mount options (comma-separated)",
-           default="noatime,nodiratime,nobarrier")
+           default=defaults['fsoptions'])
     prompt(variables, "scalyr_account_key", "Account key for your scalyr account", "")
 
     prompt(variables, 'pgpassword_superuser', "Password for PostgreSQL superuser [random]", show_default=False,
@@ -263,9 +292,8 @@ def gather_user_variables(variables, region, account_info):
     prompt(variables, 'pgpassword_standby', "Password for PostgreSQL user standby [random]", show_default=False,
            default=generate_random_password, hide_input=True, confirmation_prompt=True)
     prompt(variables, 'pgpassword_admin', "Password for PostgreSQL user admin", show_default=True,
-           default='admin', hide_input=True, confirmation_prompt=True)
+           default=defaults['pgpassword_admin'], hide_input=True, confirmation_prompt=True)
 
-    variables['kms_arn'] = None
     if click.confirm('Do you wish to encrypt these passwords using KMS?', default=False):
         kms_keys = [k for k in list_kms_keys(region) if 'alias/aws/ebs' not in k['aliases']]
 
@@ -283,8 +311,7 @@ def gather_user_variables(variables, region, account_info):
             encrypted = encrypt(region=region, KeyId=kms_keyid, Plaintext=variables[key], b64encode=True)
             variables[key] = 'aws:kms:{}'.format(encrypted)
 
-    variables['postgres_port'] = POSTGRES_PORT
-    variables['healthcheck_port'] = HEALTHCHECK_PORT
+    set_default_variables(variables)
 
     sg_name = 'app-spilo'
     rules_missing = check_security_group(sg_name,
@@ -315,6 +342,11 @@ def generate_random_password():
 
 
 def generate_definition(variables):
+    """
+    >>> variables = set_default_variables(dict())
+    >>> len(generate_definition(variables)) > 300
+    True
+    """
     definition_yaml = pystache_render(TEMPLATE, variables)
     return definition_yaml
 

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -8,7 +8,6 @@ from senza.aws import get_security_group, encrypt, list_kms_keys
 from senza.utils import pystache_render
 import requests
 import random
-import base64
 import string
 
 from ._helper import prompt, check_security_group, check_s3_bucket, get_account_alias
@@ -269,8 +268,8 @@ def gather_user_variables(variables, region, account_info):
 
         kms_keyid = kms_key.split(':')[0]
         for key in [k for k in variables if k.startswith('pgpassword_')]:
-            encrypted = encrypt(region=region, KeyId=kms_keyid, Plaintext=variables[key])
-            variables[key] = 'aws:kms:{}'.format(base64.b64encode(encrypted))
+            encrypted = encrypt(region=region, KeyId=kms_keyid, Plaintext=variables[key], encode=True)
+            variables[key] = 'aws:kms:{}'.format(encrypted)
 
     variables['postgres_port'] = POSTGRES_PORT
     variables['healthcheck_port'] = HEALTHCHECK_PORT

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -226,7 +226,7 @@ def set_default_variables(variables):
     variables.setdefault('discovery_domain', 'postgres.example.com')
     variables.setdefault('docker_image', None)
     variables.setdefault('ebs_optimized', None)
-    variables.setdefault('fsoptions','noatime,nodiratime,nobarrier')
+    variables.setdefault('fsoptions', 'noatime,nodiratime,nobarrier')
     variables.setdefault('fstype', 'ext4')
     variables.setdefault('healthcheck_port', HEALTHCHECK_PORT)
     variables.setdefault('hosted_zone', 'example.com')


### PR DESCRIPTION
To reduce the number of plaintext default passwords in configurations, the Spilo template now allows one to specify a (random) passwords. Optionally they can be stored encrypted if a suitable key is found in KMS.