### PR TITLE
Fixing get_security_group() when running it in a non-default VPC.

### DIFF
--- a/senza/aws.py
+++ b/senza/aws.py
@@ -10,7 +10,13 @@ from botocore.exceptions import ClientError
 def get_security_group(region: str, sg_name: str):
     ec2 = boto3.resource('ec2', region)
     try:
-        return list(ec2.security_groups.filter(GroupNames=[sg_name]))[0]
+        sec_groups = list(ec2.security_groups.filter(
+            Filters=[{'Name': 'group-name', 'Values': [sg_name]}]
+        ))
+        if len(sec_groups) == 0:
+            return None
+        # FIXME: What if we have 2 VPC, with a SG with the same name?!
+        return sec_groups[0]
     except ClientError as e:
         if e.response['Error']['Code'] == 'InvalidGroup.NotFound':
             return None

--- a/senza/aws.py
+++ b/senza/aws.py
@@ -13,7 +13,7 @@ def get_security_group(region: str, sg_name: str):
         sec_groups = list(ec2.security_groups.filter(
             Filters=[{'Name': 'group-name', 'Values': [sg_name]}]
         ))
-        if len(sec_groups) == 0:
+        if not sec_groups:
             return None
         # FIXME: What if we have 2 VPC, with a SG with the same name?!
         return sec_groups[0]

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -3,6 +3,14 @@ from senza.aws import resolve_topic_arn
 from senza.aws import get_security_group, resolve_security_groups, get_account_id, get_account_alias, list_kms_keys, encrypt
 
 
+def test_get_security_group(monkeypatch):
+    ec2 = MagicMock()
+    monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
+
+    results = None
+    assert results == get_security_group('myregion', 'group_inexistant')
+    
+
 def test_resolve_security_groups(monkeypatch):
     ec2 = MagicMock()
     ec2.security_groups.filter.return_value = [MagicMock(name='app-test', id='sg-test')]


### PR DESCRIPTION
get_security_group() uses the option '--group-names'

But this option only works for the default VPC. See here:
http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html

--group-names
[EC2-Classic and default VPC only] One or more security group names. You can specify either the security group name or the security group ID. For security groups in a nondefault VPC, use the group-name filter to describe security groups by name.

This pull request replaces the option group-names by a group-name filter