### PR TITLE
added possibility to expose HTTP port on ELB. 

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -20,9 +20,10 @@ def get_load_balancer_name(stack_name: str, stack_version: str):
     l = 32 - len(stack_version) - 1
     return '{}-{}'.format(stack_name[:l], stack_version)
 
-def generate_listener(protocol: str, instance_port:str, lb_port: str, ssl_cert:str, policy_names = []):
 
-    listener =  {
+def generate_listener(protocol: str, instance_port: str, lb_port: str, ssl_cert: str, policy_names=[]):
+
+    listener = {
         "PolicyNames": policy_names,
         "Protocol": protocol,
         "InstancePort": instance_port,
@@ -120,9 +121,8 @@ def component_elastic_load_balancer(definition, configuration, args, info, force
     else:
         loadbalancer_subnet_map = "LoadBalancerSubnets"
 
+    allowed_listener_protocols = {"HTTP": 80, "HTTPS": 443}
 
-    allowed_listener_protocols = {"HTTP" : 80,
-                                  "HTTPS" : 443}
     listeners = []
     if "Listeners" in configuration:
         for listener_protocol in configuration["Listeners"]:
@@ -180,5 +180,3 @@ def component_elastic_load_balancer(definition, configuration, args, info, force
             definition['Resources'][lb_name]['Properties'][key] = val
 
     return definition
-
-

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -39,6 +39,75 @@ def test_get_merged_policies(monkeypatch):
     assert [{'PolicyDocument': {'foo': 'bar'}, 'PolicyName': 'pol1'}] == get_merged_policies(['RoleA'])
 
 
+def test_component_load_balancer_listeners(monkeypatch):
+    configuration = {
+        "Name": "test_lb",
+        "SecurityGroups": "",
+        "HTTPPort": "9999",
+        "Listeners": ["HTTP","HTTPS"]
+    }
+    info = {'StackName': 'foobar', 'StackVersion': '0.1'}
+    definition = {"Resources": {}}
+
+    args = MagicMock()
+    args.region = "foo"
+
+    mock_string_result = MagicMock()
+    mock_string_result.return_value = "foo"
+    monkeypatch.setattr('senza.components.elastic_load_balancer.find_ssl_certificate_arn', mock_string_result)
+    monkeypatch.setattr('senza.components.elastic_load_balancer.resolve_security_groups', mock_string_result)
+
+    result = component_elastic_load_balancer(definition, configuration, args, info, False, MagicMock())
+
+    listeners = result["Resources"]["test_lb"]["Properties"]["Listeners"]
+
+    # should be 2 listeners
+    assert len(listeners) == 2
+
+    # should be 2 listeners with 80 and 443 ports
+    assert set([listeners[0]['LoadBalancerPort'], listeners[1]['LoadBalancerPort']]) == set([443, 80])
+
+    # should be 2 listeners with HTTP and HTTPS protocol
+    assert set([listeners[0]['Protocol'], listeners[1]['Protocol']]) == set(["HTTP", "HTTPS"])
+
+def test_component_load_balancer_default_listeners(monkeypatch):
+    configuration = {
+        "Name": "test_lb",
+        "SecurityGroups": "",
+        "HTTPPort": "9999"
+    }
+    info = {'StackName': 'foobar', 'StackVersion': '0.1'}
+    definition = {"Resources": {}}
+
+    args = MagicMock()
+    args.region = "foo"
+
+    mock_string_result = MagicMock()
+    mock_string_result.return_value = "foo"
+    monkeypatch.setattr('senza.components.elastic_load_balancer.find_ssl_certificate_arn', mock_string_result)
+    monkeypatch.setattr('senza.components.elastic_load_balancer.resolve_security_groups', mock_string_result)
+
+    # Default HTTPS listener
+    result = component_elastic_load_balancer(definition, configuration, args, info, False, MagicMock())
+
+    listeners = result["Resources"]["test_lb"]["Properties"]["Listeners"]
+
+    assert len(listeners) == 1
+    expected_listener = {
+        'LoadBalancerPort':443,
+        'InstancePort':'9999',
+        'Protocol':'HTTPS',
+        'SSLCertificateId':'foo',
+        'PolicyNames':[]
+    }
+
+    print(listeners)
+    print(expected_listener)
+
+    assert listeners[0] == expected_listener
+
+
+
 def test_component_load_balancer_healthcheck(monkeypatch):
     configuration = {
         "Name": "test_lb",

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -101,9 +101,6 @@ def test_component_load_balancer_default_listeners(monkeypatch):
         'PolicyNames':[]
     }
 
-    print(listeners)
-    print(expected_listener)
-
     assert listeners[0] == expected_listener
 
 


### PR DESCRIPTION
Usefull in case of applications with internal visibility for vpc. 
default behavior (no any additional parameters) will remain the same - only HTTPS listener

Usage in yaml file:

- AppLoadBalancer:
    Listeners:
      - HTTPS
      - HTTP
