### PR TITLE
Bugfix: Make region dependent calls explicit

### DIFF
--- a/senza/aws.py
+++ b/senza/aws.py
@@ -31,8 +31,8 @@ def get_security_group(region: str, sg_name: str):
             raise
 
 
-def get_vpc_attribute(vpc_id: str, attribute: str):
-    ec2 = boto3.resource('ec2')
+def get_vpc_attribute(region: str, vpc_id: str, attribute: str):
+    ec2 = boto3.resource('ec2', region)
     vpc = ec2.Vpc(vpc_id)
 
     return getattr(vpc, attribute, None)

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -393,7 +393,7 @@ def gather_user_variables(variables, region, account_info):
     variables['add_replica_loadbalancer'] = click.confirm('Do you want a replica ELB?', default=False)
 
     prompt(variables, 'elb_access_cidr', 'Which network should be allowed to access the ELB''s? (default=vpc)',
-           default=get_vpc_attribute(account_info.VpcID, 'cidr_block'))
+           default=get_vpc_attribute(region=region, vpc_id=account_info.VpcID, attribute='cidr_block'))
 
     odd_sg_name = 'Odd (SSH Bastion Host)'
     odd_sg = get_security_group(region, odd_sg_name)
@@ -402,7 +402,7 @@ def gather_user_variables(variables, region, account_info):
         variables['odd_sg_id'] = odd_sg.group_id
 
     # Find all Security Groups attached to the zmon worker with 'zmon' in their name
-    ec2 = boto3.client('ec2')
+    ec2 = boto3.client('ec2', region)
     filters = [{'Name': 'tag-key', 'Values': ['StackName']}, {'Name': 'tag-value', 'Values': ['zmon-worker']}]
     zmon_sgs = list()
     for reservation in ec2.describe_instances(Filters=filters).get('Reservations', []):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -66,8 +66,8 @@ def test_get_vpc_attribute(monkeypatch):
     boto3 = MagicMock()
     monkeypatch.setattr('boto3.resource', MagicMock(return_value=ec2))
 
-    assert get_vpc_attribute('a', 'VpcId') == 'dummy'
-    assert get_vpc_attribute('a', 'nonexistent') is None
+    assert get_vpc_attribute('r', 'a', 'VpcId') == 'dummy'
+    assert get_vpc_attribute('r', 'a', 'nonexistent') is None
 
 
 def test_get_account_id(monkeypatch):


### PR DESCRIPTION
Some features of the Postgresapp (Spilo) template implicitly relied upon region being set in the account_info.
It should in fact have relied upon the region explicitly specified.

Fixes https://github.com/zalando/spilo/issues/44