### PR TITLE
#177 configurable autoscaling properties

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -150,8 +150,8 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": as_conf.get("ScalingAdjustment", 1),
-                "Cooldown": as_conf.get("Cooldown", 60),
+                "ScalingAdjustment": str(as_conf.get("ScalingAdjustment", "1")),
+                "Cooldown": str(as_conf.get("Cooldown", "60")),
                 "AutoScalingGroupName": {
                     "Ref": asg_name
                 }
@@ -163,8 +163,8 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": (-1) * as_conf.get("ScalingAdjustment", 1),
-                "Cooldown": as_conf.get("Cooldown", 60),
+                "ScalingAdjustment": str((-1) * as_conf.get("ScalingAdjustment", "1")),
+                "Cooldown": str(as_conf.get("Cooldown", "60")),
                 "AutoScalingGroupName": {
                     "Ref": asg_name
                 }

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -206,7 +206,7 @@ def metric_cpu(asg_name, definition, configuration, args, info, force):
                 ],
                 "AlarmDescription": "Scale-up if CPU > {}% for {} minutes ({})".format(
                     configuration["ScaleUpThreshold"],
-                    (period / 60 ) * evaluation_periods,
+                    (period / 60) * evaluation_periods,
                     statistic
                 ),
                 "AlarmActions": [
@@ -234,7 +234,7 @@ def metric_cpu(asg_name, definition, configuration, args, info, force):
                 ],
                 "AlarmDescription": "Scale-down if CPU < {}% for {} minutes ({})".format(
                     configuration["ScaleDownThreshold"],
-                    (period / 60 ) * evaluation_periods,
+                    (period / 60) * evaluation_periods,
                     statistic
                 ),
                 "AlarmActions": [

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -193,8 +193,8 @@ def metric_cpu(asg_name, definition, configuration, args, info, force):
             "Properties": {
                 "MetricName": "CPUUtilization",
                 "Namespace": "AWS/EC2",
-                "Period": period,
-                "EvaluationPeriods": evaluation_periods,
+                "Period": str(period),
+                "EvaluationPeriods": str(evaluation_periods),
                 "Statistic": statistic,
                 "Threshold": configuration["ScaleUpThreshold"],
                 "ComparisonOperator": "GreaterThanThreshold",
@@ -221,8 +221,8 @@ def metric_cpu(asg_name, definition, configuration, args, info, force):
             "Properties": {
                 "MetricName": "CPUUtilization",
                 "Namespace": "AWS/EC2",
-                "Period": period,
-                "EvaluationPeriods": evaluation_periods,
+                "Period": str(period),
+                "EvaluationPeriods": str(evaluation_periods),
                 "Statistic": statistic,
                 "Threshold": configuration["ScaleDownThreshold"],
                 "ComparisonOperator": "LessThanThreshold",

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -145,12 +145,13 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
         asg_properties["MinSize"] = as_conf["Minimum"]
         asg_properties["DesiredCapacity"] = max(int(as_conf["Minimum"]), int(as_conf.get('DesiredCapacity', 1)))
 
+        scaling_adjustment = int(as_conf.get("ScalingAdjustment", 1))
         # ScaleUp policy
         definition["Resources"][asg_name + "ScaleUp"] = {
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": str(as_conf.get("ScalingAdjustment", "1")),
+                "ScalingAdjustment": str(scaling_adjustment),
                 "Cooldown": str(as_conf.get("Cooldown", "60")),
                 "AutoScalingGroupName": {
                     "Ref": asg_name
@@ -163,7 +164,7 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": str((-1) * as_conf.get("ScalingAdjustment", "1")),
+                "ScalingAdjustment": str((-1) * scaling_adjustment),
                 "Cooldown": str(as_conf.get("Cooldown", "60")),
                 "AutoScalingGroupName": {
                     "Ref": asg_name

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -411,8 +411,7 @@ def test_component_auto_scaling_group_configurable_properties():
             'ScaleDownThreshold': 20,
             'EvaluationPeriods': 1,
             'Cooldown': 30,
-            'Statistic': 'Maximum',
-            'ScalingAdjustment': 3
+            'Statistic': 'Maximum'
         }
     }
 
@@ -428,13 +427,13 @@ def test_component_auto_scaling_group_configurable_properties():
 
     assert result["Resources"]["FooScaleUp"] is not None
     assert result["Resources"]["FooScaleUp"]["Properties"] is not None
-    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == "3"
+    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == "1"
     assert result["Resources"]["FooScaleUp"]["Properties"]["Cooldown"] == "30"
 
     assert result["Resources"]["FooScaleDown"] is not None
     assert result["Resources"]["FooScaleDown"]["Properties"] is not None
     assert result["Resources"]["FooScaleDown"]["Properties"]["Cooldown"] == "30"
-    assert result["Resources"]["FooScaleDown"]["Properties"]["ScalingAdjustment"] == "-3"
+    assert result["Resources"]["FooScaleDown"]["Properties"]["ScalingAdjustment"] == "-1"
 
     assert result["Resources"]["Foo"] is not None
     assert result["Resources"]["Foo"]["Properties"] is not None

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -411,6 +411,7 @@ def test_component_auto_scaling_group_configurable_properties():
             'ScaleDownThreshold': 20,
             'EvaluationPeriods': 1,
             'Cooldown': 30,
+            'Statistic': 'Maximum',
             'ScalingAdjustment': 3
         }
     }
@@ -442,8 +443,8 @@ def test_component_auto_scaling_group_configurable_properties():
     assert result["Resources"]["Foo"]["Properties"]["DesiredCapacity"] == 2
     assert result["Resources"]["Foo"]["Properties"]["MaxSize"] == 10
 
-    expected_desc = "Scale-down if CPU < 20% for 1.0 minutes (Average)"
-    assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["Statistic"] == "Average"
+    expected_desc = "Scale-down if CPU < 20% for 1.0 minutes (Maximum)"
+    assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["Statistic"] == "Maximum"
     assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["Period"] == "60"
     assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["EvaluationPeriods"] == "1"
     assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["AlarmDescription"] == expected_desc

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -395,6 +395,7 @@ def test_component_taupage_auto_scaling_group_user_data_with_lists_and_empty_dic
 
     assert expected_user_data == generate_user_data(configuration)
 
+
 def test_component_auto_scaling_group_configurable_properties():
     definition = {"Resources": {}}
     configuration = {
@@ -441,10 +442,8 @@ def test_component_auto_scaling_group_configurable_properties():
     assert result["Resources"]["Foo"]["Properties"]["DesiredCapacity"] == 2
     assert result["Resources"]["Foo"]["Properties"]["MaxSize"] == 10
 
+    expected_desc = "Scale-down if CPU < 20% for 1.0 minutes (Average)"
     assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["Statistic"] == "Average"
     assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["Period"] == 60
     assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["EvaluationPeriods"] == 1
-    assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["AlarmDescription"] == "Scale-down if CPU < 20% for 1.0 minutes (Average)"
-
-    print(result)
-
+    assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["AlarmDescription"] == expected_desc

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -427,13 +427,13 @@ def test_component_auto_scaling_group_configurable_properties():
 
     assert result["Resources"]["FooScaleUp"] is not None
     assert result["Resources"]["FooScaleUp"]["Properties"] is not None
-    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == 3
-    assert result["Resources"]["FooScaleUp"]["Properties"]["Cooldown"] == 30
+    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == "3"
+    assert result["Resources"]["FooScaleUp"]["Properties"]["Cooldown"] == "30"
 
     assert result["Resources"]["FooScaleDown"] is not None
     assert result["Resources"]["FooScaleDown"]["Properties"] is not None
-    assert result["Resources"]["FooScaleDown"]["Properties"]["Cooldown"] == 30
-    assert result["Resources"]["FooScaleDown"]["Properties"]["ScalingAdjustment"] == -3
+    assert result["Resources"]["FooScaleDown"]["Properties"]["Cooldown"] == "30"
+    assert result["Resources"]["FooScaleDown"]["Properties"]["ScalingAdjustment"] == "-3"
 
     assert result["Resources"]["Foo"] is not None
     assert result["Resources"]["Foo"]["Properties"] is not None

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -444,6 +444,6 @@ def test_component_auto_scaling_group_configurable_properties():
 
     expected_desc = "Scale-down if CPU < 20% for 1.0 minutes (Average)"
     assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["Statistic"] == "Average"
-    assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["Period"] == 60
-    assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["EvaluationPeriods"] == 1
+    assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["Period"] == "60"
+    assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["EvaluationPeriods"] == "1"
     assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["AlarmDescription"] == expected_desc


### PR DESCRIPTION
Fixes #177

This PR make the following properties configurable for an AutoscalingGroup:

* Period
* EvaluationPeriods
* Statistic
* Cooldown
* ScalingAdjustment