### PR TITLE
output yaml templates

### DIFF
--- a/senza/aws.py
+++ b/senza/aws.py
@@ -1,9 +1,11 @@
+import base64
 import collections
 import datetime
 import functools
 import time
+
 import boto3
-import base64
+
 from botocore.exceptions import ClientError
 
 

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import base64
 import calendar
 import collections
 import configparser
@@ -6,37 +7,43 @@ import datetime
 import functools
 import importlib
 import ipaddress
+import json
 import os
 import re
 import sys
-import json
-from urllib.error import URLError
-import dns.resolver
 import time
+from pprint import pformat
 from subprocess import call
+from urllib.error import URLError
+from urllib.parse import quote
+from urllib.request import urlopen
+
+import boto3
+
+from botocore.exceptions import ClientError, NoCredentialsError
 
 import click
-from clickclick import AliasedGroup, Action, choice, info, FloatRange, OutputFormat, error, fatal_error, ok
-from clickclick.console import print_table
-import requests
-import yaml
-import base64
-import boto3
-from botocore.exceptions import NoCredentialsError, ClientError
 
-from .aws import parse_time, get_required_capabilities, resolve_topic_arn, get_stacks, StackReference, matches_any, \
-    get_account_id, get_account_alias, get_tag
-from .components import get_component, evaluate_template
+from clickclick import Action, AliasedGroup, FloatRange, OutputFormat, choice, error, fatal_error, info, ok
+from clickclick.console import print_table
+
+import dns.resolver
+
+import requests
+
+import senza
+
+import yaml
+
+from .aws import StackReference, get_account_alias, get_account_id, get_required_capabilities, get_stacks, \
+    get_tag, matches_any, parse_time, resolve_topic_arn
+from .components import evaluate_template, get_component
 from .components.stups_auto_configuration import find_taupage_image
+from .outputformats import load_output_format, row_data
 from .patch import patch_auto_scaling_group
 from .respawn import get_auto_scaling_group, respawn_auto_scaling_group
-import senza
-from urllib.request import urlopen
-from urllib.parse import quote
-from .traffic import change_version_traffic, print_version_traffic, get_records, get_zone
-from .utils import named_value, camel_case_to_underscore, pystache_render, ensure_keys
-from pprint import pformat
-from .outputformats import load_output_format, row_data
+from .traffic import change_version_traffic, get_records, get_zone, print_version_traffic
+from .utils import camel_case_to_underscore, ensure_keys, named_value, pystache_render
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 

--- a/senza/outputformats.py
+++ b/senza/outputformats.py
@@ -39,17 +39,5 @@ def row_data(stack, output_format):
             else:
                 row_col = column['col']
             row_dict[row_col] = getattr(stack, column['col'])
-            # if 'max-length' in column:
-            #     value_length = len(row_dict[row_col])
-            #     row_dict[row_col] = row_dict[row_col][0:column['max-length']]
-            #     if value_length > column['max-length']:
-            #         row_dict[row_col] = row_dict[row_col] + '...'
     return row_dict
 
-
-# rows.append({'stack_name': stack.name,
-#                          'stack_name': stack.name,
-#                          'version': stack.version,
-#                          'status': stack.StackStatus,
-#                          'creation_time': calendar.timegm(stack.CreationTime.timetuple()),
-#                          'description': stack.TemplateDescription})

--- a/senza/outputformats.py
+++ b/senza/outputformats.py
@@ -40,4 +40,3 @@ def row_data(stack, output_format):
                 row_col = column['col']
             row_dict[row_col] = getattr(stack, column['col'])
     return row_dict
-


### PR DESCRIPTION
please don't merge yet, this is more a proposal. i will finish it after discussion.

The output of the senza cmd's didn't suit all of my usecases. some examples:
- i want to order all stacks by creation time
- i want to restrict the description column in size
- i want the private dns name instead of private ip

therefore i started writing a general approach to configure the output via a yaml file. the current yaml file can look like this:

```yaml
outputFormats:
  list:
    sort_by:
      - CreationTime
      - "Stack Name"
      - version
    columns:
      - col: name
        alias: "Stack Name"
      - col: version
      - col: StackStatus
        alias: status
      - col: TemplateDescription
        alias: description
        max-length: 40
      - col: CreationTime
```
Has to be saved where click is finding it with `click.get_app_dir()` (http://click.pocoo.org/6/api/)

The value of `col:` can be anything from the result set of this function: http://boto3.readthedocs.org/en/latest/reference/services/cloudformation.html#CloudFormation.Client.list_stacks

open issues:
- This currently only works (and imho makes sense) with the default output style. Currently it breaks the json output, i have to investigate into this ...
- I plan to also do this for `senza instances`
- Backward compatibility/default values (currently you have to have this yaml file in place)

let's discuss ;-)