### PR TITLE
Guarantee .to_text response to be str

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -982,7 +982,10 @@ def status(stack_ref, region, output, w, watch):
                         except:
                             answers = []
                         for answer in answers:
-                            if str(answer.target.to_text()).startswith('{}-'.format(stack.StackName)):
+                            target = answer.target.to_text()
+                            if isinstance(target, bytes):
+                                target = target.decode()
+                            if target.startswith('{}-'.format(stack.StackName)):
                                 main_dns_resolves = True
 
             instances = list(ec2.instances.filter(Filters=[{'Name': 'tag:aws:cloudformation:stack-id',

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -982,7 +982,7 @@ def status(stack_ref, region, output, w, watch):
                         except:
                             answers = []
                         for answer in answers:
-                            if answer.target.to_text().startswith('{}-'.format(stack.StackName)):
+                            if str(answer.target.to_text()).startswith('{}-'.format(stack.StackName)):
                                 main_dns_resolves = True
 
             instances = list(ec2.instances.filter(Filters=[{'Name': 'tag:aws:cloudformation:stack-id',


### PR DESCRIPTION
Fixes #221 

For some reason the `dns.resolver.query(name, 'CNAME')[0].target.to_text()` returns a `bytes` string instead of `str` causing the error described in the issue. This PR guarantees that the response is a `str` instance so we can call `.startswith` with proper types.