### PR TITLE
Possibility to read parameters from file

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -568,13 +568,14 @@ def create(definition, region, version, parameter, disable_rollback, dry_run, fo
 @click.argument('version', callback=validate_version)
 @click.argument('parameter', nargs=-1)
 @region_option
+@parameter_file_option
 @click.option('--disable-rollback', is_flag=True, help='Disable Cloud Formation rollback on failure')
 @click.option('--dry-run', is_flag=True, help='No-op mode: show what would be created')
 @click.option('-f', '--force', is_flag=True, help='Ignore failing validation checks')
-def update(definition, region, version, parameter, disable_rollback, dry_run, force):
+def update(definition, region, version, parameter, disable_rollback, dry_run, force, parameter_file):
     '''Update an existing Cloud Formation stack from the given Senza definition file'''
     region = get_region(region)
-    data = create_cf_template(definition, region, version, parameter, force)
+    data = create_cf_template(definition, region, version, parameter, force, parameter_file)
     cf = boto3.client('cloudformation', region)
 
     with Action('Updating Cloud Formation stack {}..'.format(data['StackName'])) as act:

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -604,7 +604,6 @@ def print_cfjson(definition, region, version, parameter, output, force, paramete
 
 def create_cf_template(definition, region, version, parameter, force, parameter_file):
     region = get_region(region)
-    print("V2")
     if parameter_file is not None:
         parameter_from_file = read_parameter_file(parameter_file)
         parameter = parameter + parameter_from_file

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -402,12 +402,17 @@ def parse_args(input, region, version, parameter, account_info):
 def read_parameter_file(parameter_file):
     paras = []
     try:
-        with open(parameter_file, 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
-        for key, val in cfg.items():
-            paras.append("%s=%s" % (key, val))
-    except:
+        ymlfile = open(parameter_file, 'r')
+    except OSError:
         raise click.UsageError('Can\'t read parameter file "{}"'.format(parameter_file))
+
+    try:
+        cfg = yaml.load(ymlfile)
+        for key, val in cfg.items():
+            paras.append("{}={}".format(key, val))
+    except yaml.YAMLError as e:
+        raise click.UsageError('Error {}'.format(e))
+
     return tuple(paras)
 
 

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -407,7 +407,7 @@ def read_parameter_file(parameter_file):
         raise click.UsageError('Can\'t read parameter file "{}"'.format(parameter_file))
 
     try:
-        cfg = yaml.load(ymlfile)
+        cfg = yaml.safe_load(ymlfile)
         for key, val in cfg.items():
             paras.append("{}={}".format(key, val))
     except yaml.YAMLError as e:

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -613,7 +613,7 @@ def print_cfjson(definition, region, version, parameter, output, force, paramete
 
 def create_cf_template(definition, region, version, parameter, force, parameter_file):
     region = get_region(region)
-    if parameter_file is not None:
+    if parameter_file:
         parameter_from_file = read_parameter_file(parameter_file)
         parameter = parameter + parameter_from_file
     check_credentials(region)

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -398,6 +398,7 @@ def parse_args(input, region, version, parameter, account_info):
     args = TemplateArguments(region=region, version=version, **paras)
     return args
 
+
 def read_parameter_file(parameter_file):
     paras = []
     try:
@@ -408,6 +409,7 @@ def read_parameter_file(parameter_file):
     except:
         raise click.UsageError('Can\'t read parameter file "{}"'.format(parameter_file))
     return tuple(paras)
+
 
 def get_region(region):
     if not region:

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -356,6 +356,7 @@ def parse_args(input, region, version, parameter, account_info):
     paras = {}
     defaults = collections.OrderedDict()
     parameterlist = []
+    
     # process positional parameters first
     seen_keyword = False
     for i, param in enumerate(input['SenzaInfo'].get('Parameters', [])):

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -356,7 +356,7 @@ def parse_args(input, region, version, parameter, account_info):
     paras = {}
     defaults = collections.OrderedDict()
     parameterlist = []
-    
+
     # process positional parameters first
     seen_keyword = False
     for i, param in enumerate(input['SenzaInfo'].get('Parameters', [])):

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -155,6 +155,7 @@ class KeyValParamType(click.ParamType):
 
 region_option = click.option('--region', envvar='AWS_DEFAULT_REGION', metavar='AWS_REGION_ID',
                              help='AWS region ID (e.g. eu-west-1)')
+parameter_file_option = click.option('--parameter-file', help='Config file for params')
 output_option = click.option('-o', '--output', type=click.Choice(['text', 'json', 'tsv']), default='text',
                              help='Use alternative output format')
 json_output_option = click.option('-o', '--output', type=click.Choice(['json', 'yaml']), default='json',
@@ -355,7 +356,6 @@ def parse_args(input, region, version, parameter, account_info):
     paras = {}
     defaults = collections.OrderedDict()
     parameterlist = []
-
     # process positional parameters first
     seen_keyword = False
     for i, param in enumerate(input['SenzaInfo'].get('Parameters', [])):
@@ -397,6 +397,16 @@ def parse_args(input, region, version, parameter, account_info):
     args = TemplateArguments(region=region, version=version, **paras)
     return args
 
+def read_parameter_file(parameter_file):
+    paras = []
+    try:
+        with open(parameter_file, 'r') as ymlfile:
+            cfg = yaml.load(ymlfile)
+        for key, val in cfg.items():
+            paras.append("%s=%s" % (key, val))
+    except:
+        raise click.UsageError('Can\'t read parameter file "{}"'.format(parameter_file))
+    return tuple(paras)
 
 def get_region(region):
     if not region:
@@ -518,15 +528,16 @@ def list_stacks(region, stack_ref, all, output, w, watch):
 @click.argument('version', callback=validate_version)
 @click.argument('parameter', nargs=-1)
 @region_option
+@parameter_file_option
 @click.option('--disable-rollback', is_flag=True, help='Disable Cloud Formation rollback on failure')
 @click.option('--dry-run', is_flag=True, help='No-op mode: show what would be created')
 @click.option('-f', '--force', is_flag=True, help='Ignore failing validation checks')
 @click.option('-t', '--tag', help='Tags to associate with the stack.', multiple=True)
-def create(definition, region, version, parameter, disable_rollback, dry_run, force, tag):
+def create(definition, region, version, parameter, disable_rollback, dry_run, force, tag, parameter_file):
     '''Create a new Cloud Formation stack from the given Senza definition file'''
 
     region = get_region(region)
-    data = create_cf_template(definition, region, version, parameter, force)
+    data = create_cf_template(definition, region, version, parameter, force, parameter_file)
 
     for tag_kv in tag:
         try:
@@ -581,17 +592,22 @@ def update(definition, region, version, parameter, disable_rollback, dry_run, fo
 @click.argument('version', callback=validate_version)
 @click.argument('parameter', nargs=-1)
 @region_option
+@parameter_file_option
 @json_output_option
 @click.option('-f', '--force', is_flag=True, help='Ignore failing validation checks')
-def print_cfjson(definition, region, version, parameter, output, force):
+def print_cfjson(definition, region, version, parameter, output, force, parameter_file):
     '''Print the generated Cloud Formation template'''
     region = get_region(region)
-    data = create_cf_template(definition, region, version, parameter, force)
+    data = create_cf_template(definition, region, version, parameter, force, parameter_file)
     print_json(data['TemplateBody'], output)
 
 
-def create_cf_template(definition, region, version, parameter, force):
+def create_cf_template(definition, region, version, parameter, force, parameter_file):
     region = get_region(region)
+    print("V2")
+    if parameter_file is not None:
+        parameter_from_file = read_parameter_file(parameter_file)
+        parameter = parameter + parameter_from_file
     check_credentials(region)
     account_info = AccountArguments(region=region)
     args = parse_args(definition, region, version, parameter, account_info)

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -155,7 +155,7 @@ class KeyValParamType(click.ParamType):
 
 region_option = click.option('--region', envvar='AWS_DEFAULT_REGION', metavar='AWS_REGION_ID',
                              help='AWS region ID (e.g. eu-west-1)')
-parameter_file_option = click.option('--parameter-file', help='Config file for params')
+parameter_file_option = click.option('--parameter-file', help='Config file for params', metavar='PATH')
 output_option = click.option('-o', '--output', type=click.Choice(['text', 'json', 'tsv']), default='text',
                              help='Use alternative output format')
 json_output_option = click.option('-o', '--output', type=click.Choice(['json', 'yaml']), default='json',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,9 @@ def test_parameter_file_not_found():
     assert 'read parameter file "notfound.yaml"' in result.output
 
 
-def test_parameter_file_found():
+def test_parameter_file_found(monkeypatch):
+    monkeypatch.setattr('boto3.client', lambda *args: MagicMock())
+
     data = {'SenzaInfo': {'StackName': 'test', 'Parameters': [{'ApplicationId': {'Description': 'Application ID from kio'}}]}, 'Resources': {'MyQueue': {'Type': 'AWS::SQS::Queue'}}}
     param_data = { 'ApplicationId': 'test-app-id' }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,54 @@ def test_file_not_found():
     assert '"notfound.yaml" not found' in result.output
 
 
+def test_parameter_file_not_found():
+    data = {'SenzaInfo': {'StackName': 'test'}, 'Resources': {'MyQueue': {'Type': 'AWS::SQS::Queue'}}}
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+
+        result = runner.invoke(cli, ['print', '--parameter-file', 'notfound.yaml', 'myapp.yaml', '--region=myregion', '123'], catch_exceptions=False)
+
+    assert 'read parameter file "notfound.yaml"' in result.output
+
+
+def test_parameter_file_found():
+    data = {'SenzaInfo': {'StackName': 'test', 'Parameters': [{'ApplicationId': {'Description': 'Application ID from kio'}}]}, 'Resources': {'MyQueue': {'Type': 'AWS::SQS::Queue'}}}
+    param_data = { 'ApplicationId': 'test-app-id' }
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+        with open('parameter.yaml', 'w') as fd:
+            yaml.dump(param_data, fd)
+
+        result = runner.invoke(cli, ['print', '--parameter-file', 'parameter.yaml', 'myapp.yaml', '--region=myregion', '123'], catch_exceptions=False)
+
+    assert 'Generating Cloud Formation template.. OK' in result.output
+
+
+def test_parameter_file_syntax_error():
+    data = {'SenzaInfo': {'StackName': 'test', 'Parameters': [{'ApplicationId': {'Description': 'Application ID from kio'}}]}, 'Resources': {'MyQueue': {'Type': 'AWS::SQS::Queue'}}}
+    param_data = "'ApplicationId': ["
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+        with open('parameter.yaml', 'w') as fd:
+            fd.write(param_data)
+
+        result = runner.invoke(cli, ['print', '--parameter-file', 'parameter.yaml', 'myapp.yaml', '--region=myregion', '123'], catch_exceptions=False)
+
+    assert 'Error: Error while parsing a flow node' in result.output
+
+
 def test_version():
     runner = CliRunner()
     result = runner.invoke(cli, ['--version'])


### PR DESCRIPTION
This pull request would allow reading parameters from file.

Kind of what was suggested in issue #100 

The benefit would be that you could have environment specific arguments in files like..

senza create --parameter-file **ci**.yaml your-senza.yaml 1 1
senza create --parameter-file **prod**.yaml your-senza.yaml 1 1

It should work like before, so if you are missing parameter from file, that is defined senza.yaml, you need to give it from cli

senza create --parameter-file **prod**.yaml your-senza.yaml 1 1 MissingParam=TheParam




