### PR TITLE
Handle ClientError with code AccessDenied

### DIFF
--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -47,7 +47,8 @@ class HandleExceptions:
             file_name = store_exception(e)
             print('Unknown Error: {e}.\n'
                   'Please create an issue '
-                  'with the content of {fn}'.format(e=e, fn=file_name))
+                  'with the content of {fn}'.format(e=e, fn=file_name),
+                  file=sys.stderr)
             sys.exit(1)
         raise e
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock
 import yaml
 import json
 from senza.cli import cli, AccountArguments
-from senza.error_handling import HandleExceptions
 import botocore.exceptions
 from senza.traffic import PERCENT_RESOLUTION, StackVersion
 import senza.traffic
@@ -94,33 +93,6 @@ def test_version():
     runner = CliRunner()
     result = runner.invoke(cli, ['--version'])
     assert result.output.startswith('Senza ')
-
-
-def test_missing_credentials(capsys):
-    func = MagicMock(side_effect=botocore.exceptions.NoCredentialsError())
-
-    try:
-        HandleExceptions(func)()
-    except SystemExit:
-        pass
-
-    out, err = capsys.readouterr()
-    assert 'No AWS credentials found.' in err
-
-
-def test_expired_credentials(capsys):
-    func = MagicMock(side_effect=botocore.exceptions.ClientError({'Error': {'Code': 'ExpiredToken',
-                                                                            'Message': 'Token expired'}},
-                                                                 'foobar'))
-
-    try:
-        HandleExceptions(func)()
-    except SystemExit:
-        pass
-
-    out, err = capsys.readouterr()
-
-    assert 'AWS credentials have expired.' in err
 
 
 def test_print_minimal(monkeypatch):


### PR DESCRIPTION
it is now handled the same as a NoCredentialsError Exception.

ClientError with code AccessDenied can happen when switching to another AWS role
(with ``aws sts assume-role --role-arn...`` for example).
If the token returned from that command expired, we get an accessdenied.

Small refactor to avoid code duplication.