### PR TITLE
Fix infinite loop calling AWS API when using senza wait

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1477,7 +1477,7 @@ def wait(stack_ref, region, deletion, timeout, interval):
         stacks_in_progress = set()
         successful_actions = set()
 
-        stacks_found = get_stacks(stack_refs, region, all=True, unique_only=True)
+        stacks_found = list(get_stacks(stack_refs, region, all=True, unique_only=True))
 
         if not stacks_found:
             raise click.UsageError('No matching stack for "{}" found'.format(' '.join(stack_ref)))

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -6,15 +6,15 @@ def named_value(d):
     return next(iter(d.items()))
 
 
-def ensure_keys(dict, *keys):
+def ensure_keys(dict_obj, *keys):
     if len(keys) == 0:
-        return dict
+        return dict_obj
     else:
         first, rest = keys[0], keys[1:]
-        if first not in dict:
-            dict[first] = {}
-        dict[first] = ensure_keys(dict[first], *rest)
-        return dict
+        if first not in dict_obj:
+            dict_obj[first] = {}
+        dict_obj[first] = ensure_keys(dict_obj[first], *rest)
+        return dict_obj
 
 
 def camel_case_to_underscore(name):


### PR DESCRIPTION
Fixes #308

Problem was that generators are truthy so when stack were not found Senza was getting in an infinite loop.