### PR TITLE
Change traffic by updating the stack.

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -425,6 +425,7 @@ def get_region(region):
     if not region:
         raise click.UsageError('Please specify the AWS region on the command line (--region) or in ~/.aws/config')
 
+    # FIXME bool(boto3.client('cloudformation', 'moon-1')) == True
     cf = boto3.client('cloudformation', region)
     if not cf:
         raise click.UsageError('Invalid region "{}"'.format(region))

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any  # noqa: F401
 import sys
 from tempfile import NamedTemporaryFile
 from traceback import format_exception

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -95,10 +95,10 @@ class HandleExceptions:
             else:
                 self.die_unknown_error(e)
         except yaml.constructor.ConstructorError as e:
-            print("Error parsing definition file:")
-            print(e)
+            print("Error parsing definition file:", file=sys.stderr)
+            print(e, file=sys.stderr)
             if e.problem == "found unhashable key":
-                print("Please quote all variable values")
+                print("Please quote all variable values", file=sys.stderr)
             sys.exit(1)
         except PiuNotFound as e:
             error(e)

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 import sys
 from tempfile import NamedTemporaryFile
 from traceback import format_exception
@@ -36,6 +37,10 @@ def is_credentials_expired_error(client_error: ClientError) -> bool:
 
 def is_access_denied_error(e: ClientError) -> bool:
     return e.response['Error']['Code'] in ['AccessDenied']
+
+
+def is_validation_error(e: ClientError) -> bool:
+    return e.response['Error']['Code'] == 'ValidationError'
 
 
 class HandleExceptions:
@@ -81,6 +86,12 @@ class HandleExceptions:
                 sys.exit(1)
             elif is_access_denied_error(e):
                 self.die_credential_error()
+            elif is_validation_error(e):
+                response = e.response  # type: Dict[str, Dict[str, Any]]
+                err = response['Error']
+                message = err['Message']
+                error("Validation Error: {}".format(message))
+                exit(1)
             else:
                 self.die_unknown_error(e)
         except yaml.constructor.ConstructorError as e:

--- a/senza/manaus/cloudformation.py
+++ b/senza/manaus/cloudformation.py
@@ -126,7 +126,7 @@ class CloudFormationStack:
             if resource_type == ResourceType.route53_record_set:
                 records = Route53.get_records(name=resource['PhysicalResourceId'])
                 yield next(records)
-            else:
+            else:  # pragma: no cover
                 # TODO implement the other resource types
                 # Ignore resources that are still not implemented in manaus
                 pass

--- a/senza/manaus/cloudformation.py
+++ b/senza/manaus/cloudformation.py
@@ -1,9 +1,13 @@
-from typing import Optional, List, Dict, Iterator
+import json
 from collections import OrderedDict
 from datetime import datetime
 from enum import Enum
-import boto3
+from typing import Dict, Iterator, List, Optional
 
+import boto3
+from botocore.exceptions import ClientError
+
+from .exceptions import StackNotFound
 from .route53 import Route53
 
 
@@ -54,6 +58,8 @@ class CloudFormationStack:
 
         self.region = region
 
+        self.__template = None
+
     def __repr__(self):
         return "<CloudFormationStack: {name}>".format_map(vars(self))
 
@@ -94,7 +100,18 @@ class CloudFormationStack:
         """
         client = boto3.client('cloudformation', region)
 
-        stacks = client.describe_stacks(StackName=name)
+        try:
+            stacks = client.describe_stacks(StackName=name)
+        except ClientError as err:
+            response = err.response
+            error_info = response['Error']
+            error_message = error_info['Message']
+            # This is not very resilient way to do this but boto API doesn't
+            # provide a better way.
+            if error_message == 'Stack with id {name} does not exist'.format(name=name):
+                raise StackNotFound(name)
+            else:
+                raise
         stack = stacks['Stacks'][0]  # type: dict
 
         return cls.from_boto_dict(stack, region)
@@ -113,6 +130,29 @@ class CloudFormationStack:
                 # TODO implement the other resource types
                 # Ignore resources that are still not implemented in manaus
                 pass
+
+    @property
+    def template(self) -> Dict:
+        if self.__template is None:
+            client = boto3.client('cloudformation', self.region)
+            response = client.get_template(StackName=self.name)
+            self.__template = response['TemplateBody']
+        return self.__template
+
+    def reset(self):
+        self.__template = None
+
+    def update(self):
+        """
+        Sends the current template to CloudFormation to update the stack
+        """
+        client = boto3.client('cloudformation', self.region)
+        parameters = [{'ParameterKey': key, 'ParameterValue': value}
+                      for key, value in self.parameters.items()]
+        client.update_stack(StackName=self.name,
+                            TemplateBody=json.dumps(self.template),
+                            Parameters=parameters,
+                            Capabilities=self.capabilities)
 
 
 class CloudFormation:

--- a/senza/manaus/exceptions.py
+++ b/senza/manaus/exceptions.py
@@ -47,6 +47,16 @@ class StackNotFound(ManausException):
         super().__init__('CloudFormation Stack not found: {}'.format(name))
 
 
+class StackNotUpdated(ManausException):
+    """
+    Error raised when the CloudFormation Stack is not updated because no changes
+    are needed.
+    """
+
+    def __init__(self, name: str):
+        super().__init__('CloudFormation Stack not updated: {}'.format(name))
+
+
 class VPCError(ManausException, AttributeError):
     """
     Error raised when there are issues with VPCs configuration

--- a/senza/manaus/exceptions.py
+++ b/senza/manaus/exceptions.py
@@ -38,6 +38,15 @@ class RecordNotFound(ManausException):
         super().__init__('Route 53 Record not found: {}'.format(name))
 
 
+class StackNotFound(ManausException):
+    """
+    Error raised when the CloudFormation Stack is not found
+    """
+
+    def __init__(self, name: str):
+        super().__init__('CloudFormation Stack not found: {}'.format(name))
+
+
 class VPCError(ManausException, AttributeError):
     """
     Error raised when there are issues with VPCs configuration

--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -118,8 +118,7 @@ def compensate(calculation_error, compensations, identifier, new_record_weights,
     return percentage
 
 
-def set_new_weights(dns_names: list, identifier, lb_dns_name: str, new_record_weights, percentage):
-    # TODO remove percentage
+def set_new_weights(dns_names: list, identifier, lb_dns_name: str, new_record_weights):
     action('Setting weights for {dns_names}..', dns_names=', '.join(dns_names))
     for idx, dns_name in enumerate(dns_names):
         domain = dns_name.split('.', 1)[1]
@@ -356,7 +355,7 @@ def change_version_traffic(stack_ref: StackReference, percentage: float, region)
                                        deltas)
         print_traffic_changes(message)
         inform_sns(arns, message, region)
-    set_new_weights(version.dns_name, identifier, version.lb_dns_name, new_record_weights, percentage)
+    set_new_weights(version.dns_name, identifier, version.lb_dns_name, new_record_weights)
 
 
 def inform_sns(arns: list, message: str, region):

--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -1,5 +1,6 @@
 import collections
 from json import JSONEncoder
+from typing import Iterator
 
 import boto3
 import click
@@ -7,9 +8,10 @@ import dns.resolver
 from clickclick import Action, action, ok, print_table, warning
 
 from .aws import StackReference, get_stacks, get_tag
-from .manaus.elb import ELB
+from .manaus.cloudformation import CloudFormationStack
+from .manaus.exceptions import StackNotFound
 from .manaus.route53 import (RecordType, Route53, Route53HostedZone,
-                             Route53Record, convert_domain_records_to_alias)
+                             convert_domain_records_to_alias)
 
 PERCENT_RESOLUTION = 2
 FULL_PERCENTAGE = PERCENT_RESOLUTION * 100
@@ -117,55 +119,25 @@ def compensate(calculation_error, compensations, identifier, new_record_weights,
 
 
 def set_new_weights(dns_names: list, identifier, lb_dns_name: str, new_record_weights, percentage):
+    # TODO remove percentage
     action('Setting weights for {dns_names}..', dns_names=', '.join(dns_names))
-    dns_changes = collections.defaultdict(lambda: [])
     for idx, dns_name in enumerate(dns_names):
-        domain = dns_name.split('.', 1)[1]
-        hosted_zone = Route53HostedZone.get_by_domain_name(domain)
-        did_the_upsert = False
-
         convert_domain_records_to_alias(dns_name)
 
-        for r in Route53.get_records(name=dns_name):
-            if r.type in [RecordType.CNAME, RecordType.A, RecordType.AAAA]:
-                w = new_record_weights[r.set_identifier]
-                if w:
-                    if int(r.weight) != w:
-                        r.weight = w
-                        dns_changes[hosted_zone.id].append({'Action': 'UPSERT',
-                                                            'ResourceRecordSet': r.boto_dict})
-                    if identifier == r.set_identifier:
-                        did_the_upsert = True
-                else:
-                    if dns_changes.get(hosted_zone.id) is None:
-                        dns_changes[hosted_zone.id] = []
-                    dns_changes[hosted_zone.id].append({'Action': 'DELETE',
-                                                        'ResourceRecordSet': r.boto_dict.copy()})
-        if new_record_weights[identifier] > 0 and not did_the_upsert:
-            if dns_changes.get(hosted_zone.id) is None:
-                dns_changes[hosted_zone.id] = []
-            elb = ELB.get_by_dns_name(lb_dns_name[idx])
-            record = Route53Record(name=dns_name,
-                                   type=RecordType.A,
-                                   set_identifier=identifier,
-                                   weight=new_record_weights[identifier],
-                                   alias_target={"HostedZoneId": elb.hosted_zone.id,
-                                                 "DNSName": lb_dns_name[idx],
-                                                 "EvaluateTargetHealth": False})
-            dns_changes[hosted_zone.id].append({'Action': 'UPSERT',
-                                                'ResourceRecordSet': record.boto_dict})
-    if dns_changes:
-        route53 = boto3.client('route53')
-        for hosted_zone_id, change in dns_changes.items():
-            route53.change_resource_record_sets(HostedZoneId=hosted_zone_id,
-                                                ChangeBatch={'Comment': 'Weight change of {}'.format(hosted_zone_id),
-                                                             'Changes': change})
-        if sum(new_record_weights.values()) == 0:
-            ok(' DISABLED')
-        else:
-            ok()
-    else:
-        ok(' not changed')
+        # TODO pass region
+        # TODO handle not changed
+        for stack_name, percentage in new_record_weights.items():
+            try:
+                stack = CloudFormationStack.get_by_stack_name(stack_name)
+            except StackNotFound:
+                # TODO handle this correctly
+                print("FIXME: Ignored ", stack_name)
+                continue
+            load_balancer = stack.template['Resources']['AppLoadBalancerMainDomain']
+            load_balancer['Properties']['Weight'] = percentage
+            stack.update()
+
+        ok()
 
 
 def dump_traffic_changes(stack_name: str,
@@ -223,7 +195,7 @@ class StackVersion(collections.namedtuple('StackVersion', 'name version domain l
         return ['{}.'.format(x) for x in self.domain]
 
 
-def get_stack_versions(stack_name: str, region: str):
+def get_stack_versions(stack_name: str, region: str) -> Iterator[StackVersion]:
     cf = boto3.resource('cloudformation', region)
     for stack in get_stacks([StackReference(name=stack_name, version=None)], region):
         if stack.StackStatus in ('ROLLBACK_COMPLETE', 'CREATE_FAILED'):

--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -139,11 +139,15 @@ def set_new_weights(dns_names: list, identifier, lb_dns_name: str, new_record_we
                     if r.set_identifier == stack_name:
                         record = r
                         break
-                # TODO reimplement delete
-                record.weight = percentage
-                hosted_zone.upsert([record],
-                                   comment="Change weight of {} to {}".format(stack_name,
-                                                                              percentage))
+                if percentage:
+                    record.weight = percentage
+                    hosted_zone.upsert([record],
+                                       comment="Change weight of {} to {}".format(stack_name,
+                                                                                  percentage))
+                else:
+                    hosted_zone.delete([record],
+                                       comment="Delete {} "
+                                               "because traffic for it is 0".format(stack_name))
                 changed = True
                 continue
             load_balancer = stack.template['Resources']['AppLoadBalancerMainDomain']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1230,7 +1230,9 @@ def test_traffic(monkeypatch, boto_client, boto_resource):
 
     m_cfs = MagicMock()
     m_stacks = collections.defaultdict(MagicMock)
-    def get_stack(name):
+
+    def get_stack(name, region):
+        assert region == 'aa-fakeregion-1'
         if name not in m_stacks:
             stack = m_stacks[name]
             stack.template = {'Resources': {'AppLoadBalancerMainDomain':


### PR DESCRIPTION
Fixes #184 
Fixes #194

The old logic will still be applied to records that don't belong to a stack to avoid breaking something that's working. 