### PR TITLE
Add support for custom tags for both AutoScalingGroup and TaupageAutoScalingGroup

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -82,6 +82,34 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
         if "SuccessRequires" in configuration["AutoScaling"]:
             asg_success = normalize_asg_success(configuration["AutoScaling"]["SuccessRequires"])
 
+    tags = [ # Tag "Name"
+             {
+                 "Key": "Name",
+                 "PropagateAtLaunch": True,
+                 "Value": "{0}-{1}".format(info["StackName"], info["StackVersion"])
+             },
+             # Tag "StackName"
+             {
+                 "Key": "StackName",
+                 "PropagateAtLaunch": True,
+                 "Value": info["StackName"],
+             },
+             # Tag "StackVersion"
+             {
+                 "Key": "StackVersion",
+                 "PropagateAtLaunch": True,
+                 "Value": info["StackVersion"]
+             }
+           ]
+
+    if "Tags" in configuration:
+        for tag in configuration["Tags"]:
+            tags.append({
+                "Key": tag["Key"],
+                "PropagateAtLaunch": True,
+                "Value": tag["Value"]
+                })
+
     definition["Resources"][asg_name] = {
         "Type": "AWS::AutoScaling::AutoScalingGroup",
         # wait to get a signal from an amount of servers to signal that it booted
@@ -95,26 +123,7 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
             # for our operator some notifications
             "LaunchConfigurationName": {"Ref": config_name},
             "VPCZoneIdentifier": {"Fn::FindInMap": ["ServerSubnets", {"Ref": "AWS::Region"}, "Subnets"]},
-            "Tags": [
-                # Tag "Name"
-                {
-                    "Key": "Name",
-                    "PropagateAtLaunch": True,
-                    "Value": "{0}-{1}".format(info["StackName"], info["StackVersion"])
-                },
-                # Tag "StackName"
-                {
-                    "Key": "StackName",
-                    "PropagateAtLaunch": True,
-                    "Value": info["StackName"],
-                },
-                # Tag "StackVersion"
-                {
-                    "Key": "StackVersion",
-                    "PropagateAtLaunch": True,
-                    "Value": info["StackVersion"]
-                }
-            ]
+            "Tags": tags
         }
     }
 

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -82,25 +82,26 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
         if "SuccessRequires" in configuration["AutoScaling"]:
             asg_success = normalize_asg_success(configuration["AutoScaling"]["SuccessRequires"])
 
-    tags = [ # Tag "Name"
-             {
-                 "Key": "Name",
-                 "PropagateAtLaunch": True,
-                 "Value": "{0}-{1}".format(info["StackName"], info["StackVersion"])
-             },
-             # Tag "StackName"
-             {
-                 "Key": "StackName",
-                 "PropagateAtLaunch": True,
-                 "Value": info["StackName"],
-             },
-             # Tag "StackVersion"
-             {
-                 "Key": "StackVersion",
-                 "PropagateAtLaunch": True,
-                 "Value": info["StackVersion"]
-             }
-           ]
+    tags = [
+        # Tag "Name"
+        {
+            "Key": "Name",
+            "PropagateAtLaunch": True,
+            "Value": "{0}-{1}".format(info["StackName"], info["StackVersion"])
+        },
+        # Tag "StackName"
+        {
+            "Key": "StackName",
+            "PropagateAtLaunch": True,
+            "Value": info["StackName"],
+        },
+        # Tag "StackVersion"
+        {
+            "Key": "StackVersion",
+            "PropagateAtLaunch": True,
+            "Value": info["StackVersion"]
+        }
+    ]
 
     if "Tags" in configuration:
         for tag in configuration["Tags"]:
@@ -108,7 +109,7 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
                 "Key": tag["Key"],
                 "PropagateAtLaunch": True,
                 "Value": tag["Value"]
-                })
+            })
 
     definition["Resources"][asg_name] = {
         "Type": "AWS::AutoScaling::AutoScalingGroup",

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -540,6 +540,43 @@ def test_component_auto_scaling_group_configurable_properties():
     assert result["Resources"]["FooCPUAlarmHigh"]["Properties"]["EvaluationPeriods"] == "1"
     assert result["Resources"]["FooCPUAlarmLow"]["Properties"]["AlarmDescription"] == expected_desc
 
+def test_component_auto_scaling_group_custom_tags():
+    definition = {"Resources": {}}
+    configuration = {
+        'Name': 'Foo',
+        'InstanceType': 't2.micro',
+        'Image': 'foo',
+        'Tags': [ 
+            { 'Key': 'Tag1', 'Value': 'alpha' },
+            { 'Key': 'Tag2', 'Value': 'beta' }
+        ]
+    }
+
+    args = MagicMock()
+    args.region = "foo"
+
+    info = {
+        'StackName': 'FooStack',
+        'StackVersion': 'FooVersion'
+    }
+
+    result = component_auto_scaling_group(definition, configuration, args, info, False, MagicMock())
+
+    assert result["Resources"]["Foo"] is not None
+    assert result["Resources"]["Foo"]["Properties"] is not None
+    assert result["Resources"]["Foo"]["Properties"]["Tags"] is not None
+    # verify custom tags:
+    t1 = next(t for t in result["Resources"]["Foo"]["Properties"]["Tags"] if t["Key"] == 'Tag1')
+    assert t1 is not None
+    assert t1["Value"] == 'alpha'
+    t2 = next(t for t in result["Resources"]["Foo"]["Properties"]["Tags"] if t["Key"] == 'Tag2')
+    assert t2 is not None
+    assert t2["Value"] == 'beta'
+    # verify default tags are in place:
+    ts = next(t for t in result["Resources"]["Foo"]["Properties"]["Tags"] if t["Key"] == 'Name')
+    assert ts is not None
+    assert ts["Value"] == 'FooStack-FooVersion'
+
 def test_component_auto_scaling_group_configurable_properties():
     definition = {"Resources": {}}
     configuration = {


### PR DESCRIPTION
Now it is possible to specify custom tags in the autoscaling group declaration, like this:
```
   - ClusterInstance:
      Type: Senza::TaupageAutoScalingGroup
      Tags:
      -  Key: MyEnvironment
         Value: staging
      AutoScaling:
        ....
```
This function is especially useful when you need to select a particular AutoScaleGroup entity in ZMON.