### PR TITLE
#310 code cleanup and allow overwritting ELBv2 properties

### DIFF
--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -1,12 +1,8 @@
 import click
-from clickclick import fatal_error
 from senza.aws import resolve_security_groups
 from senza.components.elastic_load_balancer import ALLOWED_LOADBALANCER_SCHEMES, get_load_balancer_name, get_ssl_cert
 
 from ..cli import AccountArguments, TemplateArguments
-from ..manaus import ClientError
-from ..manaus.acm import ACM, ACMCertificate
-from ..manaus.iam import IAM, IAMServerCertificate
 from ..manaus.route53 import convert_domain_records_to_alias
 
 SENZA_PROPERTIES = frozenset(['Domains', 'HealthCheckPath', 'HealthCheckPort', 'HealthCheckProtocol',

--- a/senza/components/weighted_dns_elastic_load_balancer.py
+++ b/senza/components/weighted_dns_elastic_load_balancer.py
@@ -2,7 +2,8 @@
 from senza.components.elastic_load_balancer import component_elastic_load_balancer
 
 
-def component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info, lb_component=component_elastic_load_balancer):
+def component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info,
+                                                 lb_component=component_elastic_load_balancer):
     if 'Domains' not in configuration:
         if 'MainDomain' in configuration:
             main_domain = configuration['MainDomain']

--- a/senza/components/weighted_dns_elastic_load_balancer.py
+++ b/senza/components/weighted_dns_elastic_load_balancer.py
@@ -2,7 +2,7 @@
 from senza.components.elastic_load_balancer import component_elastic_load_balancer
 
 
-def component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info):
+def component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info, lb_component=component_elastic_load_balancer):
     if 'Domains' not in configuration:
         if 'MainDomain' in configuration:
             main_domain = configuration['MainDomain']
@@ -26,4 +26,4 @@ def component_weighted_dns_elastic_load_balancer(definition, configuration, args
                                     'VersionDomain': {'Type': 'standalone',
                                                       'Zone': '{}.'.format(version_zone.rstrip('.')),
                                                       'Subdomain': version_subdomain}}
-    return component_elastic_load_balancer(definition, configuration, args, info, force, account_info)
+    return lb_component(definition, configuration, args, info, force, account_info)

--- a/senza/components/weighted_dns_elastic_load_balancer_v2.py
+++ b/senza/components/weighted_dns_elastic_load_balancer_v2.py
@@ -4,4 +4,5 @@ from senza.components.elastic_load_balancer_v2 import component_elastic_load_bal
 
 
 def component_weighted_dns_elastic_load_balancer_v2(definition, configuration, args, info, force, account_info):
-    return component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info, component_elastic_load_balancer_v2)
+    return component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info,
+                                                        lb_component=component_elastic_load_balancer_v2)

--- a/senza/components/weighted_dns_elastic_load_balancer_v2.py
+++ b/senza/components/weighted_dns_elastic_load_balancer_v2.py
@@ -1,29 +1,7 @@
 
+from senza.components.weighted_dns_elastic_load_balancer import component_weighted_dns_elastic_load_balancer
 from senza.components.elastic_load_balancer_v2 import component_elastic_load_balancer_v2
 
 
 def component_weighted_dns_elastic_load_balancer_v2(definition, configuration, args, info, force, account_info):
-    if 'Domains' not in configuration:
-        if 'MainDomain' in configuration:
-            main_domain = configuration['MainDomain']
-            main_subdomain, main_zone = account_info.split_domain(main_domain)
-            del configuration['MainDomain']
-        else:
-            main_zone = account_info.Domain
-            main_subdomain = info['StackName']
-
-        if 'VersionDomain' in configuration:
-            version_domain = configuration['VersionDomain']
-            version_subdomain, version_zone = account_info.split_domain(version_domain)
-            del configuration['VersionDomain']
-        else:
-            version_zone = account_info.Domain
-            version_subdomain = '{}-{}'.format(info['StackName'], info['StackVersion'])
-
-        configuration['Domains'] = {'MainDomain': {'Type': 'weighted',
-                                                   'Zone': '{}.'.format(main_zone.rstrip('.')),
-                                                   'Subdomain': main_subdomain},
-                                    'VersionDomain': {'Type': 'standalone',
-                                                      'Zone': '{}.'.format(version_zone.rstrip('.')),
-                                                      'Subdomain': version_subdomain}}
-    return component_elastic_load_balancer_v2(definition, configuration, args, info, force, account_info)
+    return component_weighted_dns_elastic_load_balancer(definition, configuration, args, info, force, account_info, component_elastic_load_balancer_v2)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -579,7 +579,7 @@ def test_component_auto_scaling_group_custom_tags():
     assert ts is not None
     assert ts["Value"] == 'FooStack-FooVersion'
 
-def test_component_auto_scaling_group_configurable_properties():
+def test_component_auto_scaling_group_configurable_properties2():
     definition = {"Resources": {}}
     configuration = {
         'Name': 'Foo',


### PR DESCRIPTION
#310: Further steps towards full ELBv2 support

* remove duplicate code
* allow overwriting ELBv2 / target group properties
* default health check path is now '/health' (much more reasonable, "/ui/" was just convenient for original STUPS microservices)