### PR TITLE
Fix bad message credential access error

### DIFF
--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -95,7 +95,7 @@ class HandleExceptions:
             err_mesg = "Error parsing definition file:\n{}".format(e)
             if e.problem == "found unhashable key":
                 err_mesg += "Please quote all variable values"
-                die_fatal_error(err_mesg)
+            die_fatal_error(err_mesg)
         except PiuNotFound as e:
             die_fatal_error(
                 "{}\nYou can install piu with the following command:"

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -87,7 +87,7 @@ class HandleExceptions:
                         e.response['Error']['Message']))
             elif is_validation_error(e):
                 die_fatal_error(
-                    "Validation Error: \n{}".format(
+                    "Validation Error: {}".format(
                         e.response['Error']['Message']))
             else:
                 self.die_unknown_error(e)

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -5,7 +5,7 @@ from traceback import format_exception
 
 import yaml.constructor
 from botocore.exceptions import ClientError, NoCredentialsError
-from clickclick import error
+from clickclick import error, fatal_error
 
 from .exceptions import PiuNotFound, InvalidDefinition
 from .manaus.exceptions import (ELBNotFound, HostedZoneNotFound, InvalidState,
@@ -43,6 +43,11 @@ def is_validation_error(e: ClientError) -> bool:
     return e.response['Error']['Code'] == 'ValidationError'
 
 
+def die_fatal_error(mesg):
+    """Sent error message to stderr, in red, and exit"""
+    fatal_error(mesg, err=True)
+
+
 class HandleExceptions:
     """Class HandleExceptions will display various error messages
     depending on the type of the exception and show the stacktrack for general exceptions
@@ -56,64 +61,50 @@ class HandleExceptions:
     def die_unknown_error(self, e: Exception):
         if not self.stacktrace_visible:
             file_name = store_exception(e)
-            print('Unknown Error: {e}.\n'
+            die_fatal_error('Unknown Error: {e}.\n'
                   'Please create an issue '
-                  'with the content of {fn}'.format(e=e, fn=file_name),
-                  file=sys.stderr)
-            sys.exit(1)
+                  'with the content of {fn}'.format(e=e, fn=file_name))
         raise e
-
-    def die_credential_error(self):
-        print('No AWS credentials found. Use the "mai" command-line tool '
-              'to get a temporary access key\n'
-              'or manually configure either ~/.aws/credentials '
-              'or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.',
-              file=sys.stderr)
-        sys.exit(1)
 
     def __call__(self, *args, **kwargs):
         try:
             self.function(*args, **kwargs)
         except NoCredentialsError:
-            self.die_credential_error()
+            die_fatal_error(
+                'No AWS credentials found. Use the "mai" command-line tool '
+                'to get a temporary access key\n'
+                'or manually configure either ~/.aws/credentials '
+                'or AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.')
         except ClientError as e:
             sys.stdout.flush()
             if is_credentials_expired_error(e):
-                print('AWS credentials have expired.\n'
+                die_fatal_error('AWS credentials have expired.\n'
                       'Use the "mai" command line tool to get a new'
-                      ' temporary access key.',
-                      file=sys.stderr)
-                sys.exit(1)
+                      ' temporary access key.')
             elif is_access_denied_error(e):
-                self.die_credential_error()
+                die_fatal_error(
+                    "AWS missing access rights.\n{}".format(
+                        e.response['Error']['Message']))
             elif is_validation_error(e):
-                response = e.response  # type: Dict[str, Dict[str, Any]]
-                err = response['Error']
-                message = err['Message']
-                error("Validation Error: {}".format(message))
-                exit(1)
+                die_fatal_error(
+                    "Validation Error: \n{}".format(
+                        e.response['Error']['Message']))
             else:
                 self.die_unknown_error(e)
         except yaml.constructor.ConstructorError as e:
-            print("Error parsing definition file:", file=sys.stderr)
-            print(e, file=sys.stderr)
+            err_mesg = "Error parsing definition file:\n{}".format(e)
             if e.problem == "found unhashable key":
-                print("Please quote all variable values", file=sys.stderr)
-            sys.exit(1)
+                err_mesg += "Please quote all variable values"
+                die_fatal_error(err_mesg)
         except PiuNotFound as e:
-            error(e)
-            print("You can install piu with the following command:",
-                  file=sys.stderr)
-            print("sudo pip3 install --upgrade stups-piu",
-                  file=sys.stderr)
-            sys.exit(1)
+            die_fatal_error(
+                "{}\nYou can install piu with the following command:"
+                "\nsudo pip3 install --upgrade stups-piu".format(e))
         except InvalidState as e:
-            error('Invalid State: {}'.format(e))
-            sys.exit(1)
+            die_fatal_error('Invalid State: {}'.format(e))
         except (ELBNotFound, HostedZoneNotFound, RecordNotFound,
                 InvalidDefinition) as e:
-            error(e)
-            sys.exit(1)
+            die_fatal_error(e)
         except Exception as e:
             # Catch All
             self.die_unknown_error(e)

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -5,7 +5,7 @@ from traceback import format_exception
 
 import yaml.constructor
 from botocore.exceptions import ClientError, NoCredentialsError
-from clickclick import error, fatal_error
+from clickclick import fatal_error
 
 from .exceptions import PiuNotFound, InvalidDefinition
 from .manaus.exceptions import (ELBNotFound, HostedZoneNotFound, InvalidState,
@@ -62,8 +62,8 @@ class HandleExceptions:
         if not self.stacktrace_visible:
             file_name = store_exception(e)
             die_fatal_error('Unknown Error: {e}.\n'
-                  'Please create an issue '
-                  'with the content of {fn}'.format(e=e, fn=file_name))
+                            'Please create an issue with the '
+                            'content of {fn}'.format(e=e, fn=file_name))
         raise e
 
     def __call__(self, *args, **kwargs):
@@ -79,8 +79,8 @@ class HandleExceptions:
             sys.stdout.flush()
             if is_credentials_expired_error(e):
                 die_fatal_error('AWS credentials have expired.\n'
-                      'Use the "mai" command line tool to get a new'
-                      ' temporary access key.')
+                                'Use the "mai" command line tool to get a new '
+                                'temporary access key.')
             elif is_access_denied_error(e):
                 die_fatal_error(
                     "AWS missing access rights.\n{}".format(

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -99,9 +99,12 @@ def test_missing_credentials(capsys):
     out, err = capsys.readouterr()
     assert 'No AWS credentials found.' in err
 
+
+def test_access_denied(capsys):
+    err_mesg = "User: myuser is not authorized to perform: service:TaskName"
     func = MagicMock(side_effect=botocore.exceptions.ClientError(
         {'Error': {'Code': 'AccessDenied',
-                   'Message': 'User: myuser is not authorized to perform: service:TaskName'}},
+                   'Message': err_mesg}},
         'foobar'))
 
     try:
@@ -111,7 +114,8 @@ def test_missing_credentials(capsys):
 
     out, err = capsys.readouterr()
 
-    assert 'No AWS credentials found.' in err
+    assert 'AWS missing access rights.' in err
+    assert err_mesg in err
 
 
 def test_expired_credentials(capsys):


### PR DESCRIPTION
When getting the error: access_denied_error (which means: credentials are present in .aws/credentials or in env variables, but the associated user does not have proper access rights on the AWS resource),

Senza reported:
No AWS credentials found. Use the "mai" command-line tool to get a temporary access key
or manually configure either ~/.aws/credentials or WS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.

Which is not correct: the credentials ARE present. That cost me a bit of time to find the issue.

Also,
- DRY up the code: do not repeat exit(1) all the time.
- Display errors using the clickclick.fatal_error function, which colors the error in red all the time.