### PR TITLE
Boto.client proxy to retry on throttling

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -33,8 +33,9 @@ from .aws import (StackReference, get_account_alias, get_account_id,
                   parse_time, resolve_topic_arn)
 from .components import evaluate_template, get_component
 from .components.stups_auto_configuration import find_taupage_image
-from .exceptions import InvalidDefinition
 from .error_handling import HandleExceptions
+from .exceptions import InvalidDefinition
+from .manaus.boto_proxy import BotoClientProxy
 from .manaus.cloudformation import CloudFormation
 from .manaus.ec2 import EC2
 from .manaus.exceptions import VPCError
@@ -419,15 +420,15 @@ def get_region(region):
     if not region:
         raise click.UsageError('Please specify the AWS region on the command line (--region) or in ~/.aws/config')
 
-    # FIXME bool(boto3.client('cloudformation', 'moon-1')) == True
-    cf = boto3.client('cloudformation', region)
+    # FIXME bool(BotoClientProxy('cloudformation', 'moon-1')) == True
+    cf = BotoClientProxy('cloudformation', region)
     if not cf:
         raise click.UsageError('Invalid region "{}"'.format(region))
     return region
 
 
 def check_credentials(region):
-    iam = boto3.client('iam')
+    iam = BotoClientProxy('iam')
     return iam.list_account_aliases()
 
 
@@ -605,7 +606,7 @@ def health(region, stack_ref, all, output, w, watch):
     region = get_region(region)
     check_credentials(region)
 
-    cloudwatch = boto3.client('cloudwatch', region)
+    cloudwatch = BotoClientProxy('cloudwatch', region)
 
     stack_refs = get_stack_refs(stack_ref)
 
@@ -670,7 +671,7 @@ def create(definition, region, version, parameter, disable_rollback, dry_run,
             fatal_error('Invalid tag {}. Tags should be in the form of key=value'.format(tag_kv))
         data['Tags'].append({'Key': key, 'Value': value})
 
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     with Action('Creating Cloud Formation stack {}..'.format(data['StackName'])) as act:
         try:
@@ -702,7 +703,7 @@ def update(definition, region, version, parameter, disable_rollback, dry_run,
 
     region = get_region(region)
     data = create_cf_template(definition, region, version, parameter, force, parameter_file)
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     with Action('Updating Cloud Formation stack {}..'.format(data['StackName'])) as act:
         try:
@@ -867,7 +868,7 @@ def resources(stack_ref, region, w, watch, output):
     stack_refs = get_stack_refs(stack_ref)
     region = get_region(region)
     check_credentials(region)
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     for _ in watching(w, watch):
         rows = []
@@ -902,7 +903,7 @@ def events(stack_ref, region, w, watch, output):
     stack_refs = get_stack_refs(stack_ref)
     region = get_region(region)
     check_credentials(region)
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     for _ in watching(w, watch):
         rows = []
@@ -964,7 +965,7 @@ def get_instance_health(stack_name: str, region: str) -> dict:
     if stack_name is None:
         return {}
     instance_health = {}
-    elb = boto3.client('elb', region)
+    elb = BotoClientProxy('elb', region)
     try:
         instance_states = elb.describe_instance_health(LoadBalancerName=stack_name)['InstanceStates']
         for istate in instance_states:
@@ -972,7 +973,7 @@ def get_instance_health(stack_name: str, region: str) -> dict:
     except ClientError as e:
         # retry with ELBv2
         if e.response['Error']['Code'] == 'LoadBalancerNotFound':
-            elbv2 = boto3.client('elbv2', region)
+            elbv2 = BotoClientProxy('elbv2', region)
             try:
                 response = elbv2.describe_target_groups(Names=[stack_name])
                 for tg in response['TargetGroups']:
@@ -1414,7 +1415,7 @@ def dump(stack_ref, region, output):
     region = get_region(region)
     check_credentials(region)
 
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     for stack in get_stacks(stack_refs, region):
         data = cf.get_template(StackName=stack.StackName)['TemplateBody']
@@ -1423,7 +1424,7 @@ def dump(stack_ref, region, output):
 
 
 def get_auto_scaling_groups(stack_refs, region):
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
     for stack in get_stacks(stack_refs, region):
         resources = cf.describe_stack_resources(StackName=stack.StackName)['StackResources']
 
@@ -1466,7 +1467,7 @@ def patch(stack_ref, region, image, instance_type, user_data):
     if not properties:
         raise click.UsageError('Nothing to patch. Please specify at least one patch option (e.g. "--image").')
 
-    asg = boto3.client('autoscaling', region)
+    asg = BotoClientProxy('autoscaling', region)
 
     for asg_name in get_auto_scaling_groups(stack_refs, region):
         with Action('Patching Auto Scaling Group {}..'.format(asg_name)) as act:
@@ -1511,7 +1512,7 @@ def scale(stack_ref, region, desired_capacity):
     region = get_region(region)
     check_credentials(region)
 
-    asg = boto3.client('autoscaling', region)
+    asg = BotoClientProxy('autoscaling', region)
 
     for asg_name in get_auto_scaling_groups(stack_refs, region):
         group = get_auto_scaling_group(asg, asg_name)
@@ -1559,7 +1560,7 @@ def wait(stack_ref, region, deletion, timeout, interval):
 
     stack_refs = get_stack_refs(stack_ref)
     region = get_region(region)
-    cf = boto3.client('cloudformation', region)
+    cf = BotoClientProxy('cloudformation', region)
 
     target_status = (['DELETE_COMPLETE'] if deletion
                      else ['CREATE_COMPLETE', 'UPDATE_COMPLETE'])

--- a/senza/manaus/acm.py
+++ b/senza/manaus/acm.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Iterator, List, Dict, Any, Optional
 from functools import total_ordering
-from ssl import match_hostname, CertificateError
+from ssl import CertificateError, match_hostname
+from typing import Any, Dict, Iterator, List, Optional
 
-import boto3
+from .boto_proxy import BotoClientProxy
 
 
 class ACMCertificateStatus(str, Enum):
@@ -105,7 +105,7 @@ class ACMCertificate:
         """
         Gets a ACMCertificate based on ARN alone
         """
-        client = boto3.client('acm', region)
+        client = BotoClientProxy('acm', region)
         certificate = client.describe_certificate(CertificateArn=arn)['Certificate']
         return cls.from_boto_dict(certificate)
 
@@ -171,7 +171,7 @@ class ACM:
         :param domain_name: Return only certificates that match the domain
         """
         # TODO implement pagination
-        client = boto3.client('acm', self.region)
+        client = BotoClientProxy('acm', self.region)
         certificates = client.list_certificates()['CertificateSummaryList']
         for summary in certificates:
             arn = summary['CertificateArn']

--- a/senza/manaus/boto_proxy.py
+++ b/senza/manaus/boto_proxy.py
@@ -1,0 +1,38 @@
+from time import sleep
+
+import boto3
+from botocore.exceptions import ClientError
+
+__all__ = ['BotoClientProxy']
+
+
+class BotoClientProxy:
+    def __init__(self, *args, **kwargs):
+        self.__client = boto3.client(*args, **kwargs)
+
+    @staticmethod
+    def __decorator(function, *args, **kwargs):
+        def wrapper(*args, **kwargs):
+            max_tries = 5  # TODO make configurable
+            sleep_time = 5  # TODO make configurable
+            last_error = None
+            for i in range(max_tries):
+                try:
+                    return function(*args, **kwargs)
+                except ClientError as error:
+                    last_error = error
+                    if error.response['Error']['Code'] == "Throttling":
+                        sleep(sleep_time)
+                    else:
+                        raise
+            else:
+                if last_error:
+                    raise last_error
+        return wrapper
+
+    def __getattr__(self, item):
+        client_attr = getattr(self.__client, item)
+        if callable(client_attr):
+            return self.__decorator(client_attr)
+        else:
+            return client_attr

--- a/senza/manaus/boto_proxy.py
+++ b/senza/manaus/boto_proxy.py
@@ -3,6 +3,7 @@ from time import sleep
 import boto3
 from botocore.exceptions import ClientError
 
+
 __all__ = ['BotoClientProxy']
 
 
@@ -13,8 +14,8 @@ class BotoClientProxy:
     @staticmethod
     def __decorator(function, *args, **kwargs):
         def wrapper(*args, **kwargs):
-            max_tries = 5  # TODO make configurable
-            sleep_time = 5  # TODO make configurable
+            max_tries = 5
+            sleep_time = 10
             last_error = None
             for i in range(max_tries):
                 try:

--- a/senza/manaus/cloudformation.py
+++ b/senza/manaus/cloudformation.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Iterator, List, Optional
 
-import boto3
 from botocore.exceptions import ClientError
 
+from .boto_proxy import BotoClientProxy
 from .exceptions import StackNotFound, StackNotUpdated
 from .route53 import Route53
 
@@ -98,7 +98,7 @@ class CloudFormationStack:
         See:
         http://boto3.readthedocs.io/en/latest/reference/services/cloudformation.html#CloudFormation.Client.describe_stacks
         """
-        client = boto3.client('cloudformation', region)
+        client = BotoClientProxy('cloudformation', region)
 
         try:
             stacks = client.describe_stacks(StackName=name)
@@ -118,7 +118,7 @@ class CloudFormationStack:
 
     @property
     def resources(self) -> Iterator:
-        client = boto3.client('cloudformation', self.region)
+        client = BotoClientProxy('cloudformation', self.region)
         response = client.list_stack_resources(StackName=self.stack_id)
         resources = response['StackResourceSummaries']  # type: List[Dict]
         for resource in resources:
@@ -137,7 +137,7 @@ class CloudFormationStack:
     @property
     def template(self) -> Dict:
         if self.__template is None:
-            client = boto3.client('cloudformation', self.region)
+            client = BotoClientProxy('cloudformation', self.region)
             response = client.get_template(StackName=self.name)
             self.__template = response['TemplateBody']
         return self.__template
@@ -149,7 +149,7 @@ class CloudFormationStack:
         """
         Sends the current template to CloudFormation to update the stack
         """
-        client = boto3.client('cloudformation', self.region)
+        client = BotoClientProxy('cloudformation', self.region)
         parameters = [{'ParameterKey': key, 'ParameterValue': value}
                       for key, value in self.parameters.items()]
         try:
@@ -167,7 +167,7 @@ class CloudFormationStack:
                 raise
 
     def delete(self):
-        client = boto3.client('cloudformation', self.region)
+        client = BotoClientProxy('cloudformation', self.region)
         client.delete_stack(StackName=self.stack_id)
 
 
@@ -177,7 +177,7 @@ class CloudFormation:
         self.region = region
 
     def get_stacks(self, all: bool=False):
-        client = boto3.client('cloudformation', self.region)
+        client = BotoClientProxy('cloudformation', self.region)
         if all:
             status_filter = []
         else:

--- a/senza/manaus/ec2.py
+++ b/senza/manaus/ec2.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, List, Iterator, Optional
+from typing import Dict, Iterator, List, Optional
 
 import boto3
 

--- a/senza/manaus/elb.py
+++ b/senza/manaus/elb.py
@@ -2,8 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import boto3
-
+from .boto_proxy import BotoClientProxy
 from .exceptions import ELBNotFound
 from .route53 import Route53HostedZone
 
@@ -161,7 +160,7 @@ class ELB:
     @classmethod
     def get_by_dns_name(cls, dns_name: str) -> "ELB":
         _, region, _ = dns_name.split('.', maxsplit=2)
-        client = boto3.client('elb', region)
+        client = BotoClientProxy('elb', region)
 
         # TODO pagination
         response = client.describe_load_balancers()

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Iterator, Optional, Union
 import boto3
 from botocore.exceptions import ClientError
 
+from .boto_proxy import BotoClientProxy
+
 
 class IAMServerCertificate:
     """
@@ -65,7 +67,7 @@ class IAMServerCertificate:
         """
         Get IAMServerCertificate using the name of the server certificate
         """
-        client = boto3.client('iam', region)
+        client = BotoClientProxy('iam', region)
         iam = IAM(region)
 
         try:

--- a/senza/manaus/route53.py
+++ b/senza/manaus/route53.py
@@ -4,9 +4,9 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-import boto3
 from click import confirm
 
+from .boto_proxy import BotoClientProxy
 from .exceptions import (ELBNotFound, HostedZoneNotFound, InvalidState,
                          RecordNotFound)
 
@@ -102,7 +102,7 @@ class Route53HostedZone:
         http://boto3.readthedocs.io/en/latest/reference/services/route53.html#Route53.Client.change_resource_record_sets
         """
 
-        client = boto3.client('route53')
+        client = BotoClientProxy('route53')
 
         change_batch = {'Changes': []}
         if comment is not None:
@@ -310,7 +310,7 @@ class Route53Record:
 class Route53:
 
     def __init__(self):
-        self.client = boto3.client('route53')
+        self.client = BotoClientProxy('route53')
 
     @staticmethod
     def get_hosted_zones(domain_name: Optional[str]=None,
@@ -323,7 +323,7 @@ class Route53:
         if domain_name is not None:
             domain_name = '{}.'.format(domain_name.rstrip('.'))
 
-        client = boto3.client('route53')
+        client = BotoClientProxy('route53')
         result = client.list_hosted_zones()
         hosted_zones = result["HostedZones"]
         while result.get('IsTruncated', False):
@@ -345,7 +345,7 @@ class Route53:
     @classmethod
     def get_records(cls, *,
                     name: Optional[str]=None) -> Iterator[Route53Record]:
-        client = boto3.client('route53')
+        client = BotoClientProxy('route53')
         if name is not None and not name.endswith('.'):
             name += '.'
         for zone in cls.get_hosted_zones():

--- a/senza/patch.py
+++ b/senza/patch.py
@@ -1,8 +1,10 @@
 
-import boto3
 import codecs
 import datetime
+
 import yaml
+
+from .manaus.boto_proxy import BotoClientProxy
 
 LAUNCH_CONFIGURATION_PROPERTIES = set([
     'AssociatePublicIpAddress',
@@ -36,7 +38,7 @@ def patch_user_data(old: str, new: dict):
 
 
 def patch_auto_scaling_group(group: dict, region: str, properties: dict):
-    asg = boto3.client('autoscaling', region)
+    asg = BotoClientProxy('autoscaling', region)
     result = asg.describe_launch_configurations(LaunchConfigurationNames=[group['LaunchConfigurationName']])
     lcs = result['LaunchConfigurations']
     changed = False

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -9,6 +9,8 @@ from click import confirm
 from clickclick import Action
 from senza.aws import get_account_alias, get_account_id, get_security_group
 
+from ..manaus.boto_proxy import BotoClientProxy
+
 
 def prompt(variables: dict, var_name, *args, **kwargs):
     if var_name not in variables:
@@ -69,7 +71,7 @@ def check_security_group(sg_name, rules, region, allow_from_self=False):
         create_sg = click.confirm('Security group {} does not exist. Do you want Senza to create it now?'.format(
             sg_name), default=True)
         if create_sg:
-            ec2c = boto3.client('ec2', region)
+            ec2c = BotoClientProxy('ec2', region)
             # FIXME which vpc?
             vpc = ec2c.describe_vpcs()['Vpcs'][0]
             sg = ec2c.create_security_group(GroupName=sg_name,
@@ -131,7 +133,7 @@ def get_iam_role_policy(application_id: str, bucket_name: str, region: str):
 def check_iam_role(application_id: str, bucket_name: str, region: str):
     role_name = 'app-{}'.format(application_id)
     with Action('Checking IAM role {}..'.format(role_name)):
-        iam = boto3.client('iam')
+        iam = BotoClientProxy('iam')
         try:
             iam.get_role(RoleName=role_name)
             exists = True

--- a/senza/templates/postgresapp.py
+++ b/senza/templates/postgresapp.py
@@ -2,17 +2,18 @@
 HA Postgres app, which needs an S3 bucket to store WAL files
 '''
 
-import click
-from clickclick import choice, warning
-from senza.aws import encrypt, list_kms_keys, get_vpc_attribute, get_security_group
-from senza.utils import pystache_render
-import requests
 import random
 import string
-import boto3
 
+import click
+import requests
+from clickclick import choice, warning
+from senza.aws import (encrypt, get_security_group, get_vpc_attribute,
+                       list_kms_keys)
+from senza.utils import pystache_render
 
-from ._helper import prompt, check_s3_bucket, get_account_alias
+from ..manaus.boto_proxy import BotoClientProxy
+from ._helper import check_s3_bucket, get_account_alias, prompt
 
 POSTGRES_PORT = 5432
 HEALTHCHECK_PORT = 8008
@@ -414,7 +415,7 @@ def gather_user_variables(variables, region, account_info):
         variables['odd_sg_id'] = odd_sg.group_id
 
     # Find all Security Groups attached to the zmon worker with 'zmon' in their name
-    ec2 = boto3.client('ec2', region)
+    ec2 = BotoClientProxy('ec2', region)
     filters = [{'Name': 'tag-key', 'Values': ['StackName']}, {'Name': 'tag-value', 'Values': ['zmon-appliance']}]
     zmon_sgs = list()
     for reservation in ec2.describe_instances(Filters=filters).get('Reservations', []):

--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -8,8 +8,9 @@ import dns.resolver
 from clickclick import Action, action, ok, print_table, warning
 
 from .aws import StackReference, get_stacks, get_tag
+from .manaus.boto_proxy import BotoClientProxy
 from .manaus.cloudformation import CloudFormationStack, ResourceType
-from .manaus.exceptions import StackNotFound, StackNotUpdated, ELBNotFound
+from .manaus.exceptions import ELBNotFound, StackNotFound, StackNotUpdated
 from .manaus.route53 import (RecordType, Route53, Route53HostedZone,
                              convert_domain_records_to_alias)
 
@@ -252,7 +253,7 @@ def get_stack_versions(stack_name: str, region: str) -> Iterator[StackVersion]:
         notification_arns = details.notification_arns
         for res in details.resource_summaries.all():
             if res.resource_type == 'AWS::ElasticLoadBalancing::LoadBalancer':
-                elb = boto3.client('elb', region)
+                elb = BotoClientProxy('elb', region)
                 lbs = elb.describe_load_balancers(LoadBalancerNames=[res.physical_resource_id])
                 lb_dns_name.append(lbs['LoadBalancerDescriptions'][0]['DNSName'])
             elif res.resource_type == 'AWS::Route53::RecordSet':
@@ -272,7 +273,7 @@ def get_records(domain: str):
     domain = '{}.'.format(domain.rstrip('.'))
     if DNS_RR_CACHE.get(domain) is None:
         hosted_zone = Route53HostedZone.get_by_domain_name(domain)
-        route53 = boto3.client('route53')
+        route53 = BotoClientProxy('route53')
         result = route53.list_resource_record_sets(HostedZoneId=hosted_zone.id)
         records = result['ResourceRecordSets']
         while result['IsTruncated']:
@@ -386,7 +387,7 @@ def change_version_traffic(stack_ref: StackReference, percentage: float,
 def inform_sns(arns: list, message: str, region):
     jsonizer = JSONEncoder()
     sns_topics = set(arns)
-    sns = boto3.client('sns', region_name=region)
+    sns = BotoClientProxy('sns', region_name=region)
     for sns_topic in sns_topics:
         sns.publish(TopicArn=sns_topic, Subject="SenzaTrafficRedirect", Message=jsonizer.encode((message)))
 

--- a/tests/test_manaus/test_boto_proxy.py
+++ b/tests/test_manaus/test_boto_proxy.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+import botocore.exceptions
+import pytest
+from senza.manaus.boto_proxy import BotoClientProxy
+
+
+@pytest.fixture(autouse=True)
+def mock_boto_client(monkeypatch):
+    m = MagicMock(p=42)
+    m.return_value = m
+    monkeypatch.setattr('boto3.client', m)
+    return m
+
+
+def test_proxy(mock_boto_client: MagicMock):
+    proxy = BotoClientProxy('test')
+    mock_boto_client.assert_called_once_with('test')
+    proxy.random_test(42)
+    mock_boto_client.random_test.assert_called_once_with(42)
+    assert proxy.random_test is not mock_boto_client.random_test
+    assert proxy.p is mock_boto_client.p
+
+
+def test_throttling(mock_boto_client: MagicMock, monkeypatch):
+    monkeypatch.setattr('senza.manaus.boto_proxy.sleep', MagicMock())
+    i = 0
+
+    def throttled(arg):
+        nonlocal i
+        if i < 3:
+            i += 1
+            raise botocore.exceptions.ClientError(
+                {'Error': {'Code': 'Throttling'}},
+                'testing'
+            )
+        else:
+            return arg
+
+    mock_boto_client.throttled.side_effect = throttled
+    proxy = BotoClientProxy('test')
+    mock_boto_client.assert_called_once_with('test')
+    assert proxy.throttled(42) == 42
+    mock_boto_client.throttled.assert_called_with(42)
+    assert mock_boto_client.throttled.call_count == 4
+
+
+def test_throttling_forever(mock_boto_client: MagicMock, monkeypatch):
+    monkeypatch.setattr('senza.manaus.boto_proxy.sleep', MagicMock())
+
+    def throttled(arg):
+        raise botocore.exceptions.ClientError(
+            {'Error': {'Code': 'Throttling'}},
+            'testing'
+        )
+
+    mock_boto_client.throttled.side_effect = throttled
+    proxy = BotoClientProxy('test')
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        proxy.throttled(42)
+    mock_boto_client.throttled.assert_called_with(42)
+    assert mock_boto_client.throttled.call_count == 5
+
+
+def test_random_error(mock_boto_client: MagicMock, monkeypatch):
+    monkeypatch.setattr('senza.manaus.boto_proxy.sleep', MagicMock())
+
+    def throttled(arg):
+        raise botocore.exceptions.ClientError(
+            {'Error': {'Code': "everyday i'm shuffling"}},
+            'testing'
+        )
+
+    mock_boto_client.throttled.side_effect = throttled
+    proxy = BotoClientProxy('test')
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        proxy.throttled(42)
+    mock_boto_client.throttled.assert_called_with(42)
+    assert mock_boto_client.throttled.call_count == 1


### PR DESCRIPTION
Fixes #137

`BotoClientProxy` replaces `boto3.client` and works by passing every call to an internal instance of `boto3.client` but retrying the call if it gets a throttling exception.