### PR TITLE
Validate region against a list provided by boto3

### DIFF
--- a/senza/arguments.py
+++ b/senza/arguments.py
@@ -1,18 +1,21 @@
-import re
-
+import boto3.session
 import click
 
 from .error_handling import HandleExceptions
 
-REGION_PATTERN = re.compile(r'^[a-z]{2}-[a-z]+-[0-9]$')
-
 
 def validate_region(ctx, param, value):
     """Validate Click region param parameter."""
+
     if value is not None:
-        if not REGION_PATTERN.match(value):
-            raise click.BadParameter("'{}'. Region must be a valid "
-                                     "AWS region.".format(value))
+        session = boto3.session.Session()
+        valid_regions = session.get_available_regions('cloudformation')
+        if value not in valid_regions:
+            valid_regions.sort()
+            raise click.BadParameter("'{}'. Region must be one of the "
+                                     "following AWS regions:\n"
+                                     "  - {}".format(value,
+                                                     "\n  - ".join(valid_regions)))
     return value
 
 

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -417,12 +417,9 @@ def get_region(region):
             pass
 
     if not region:
-        raise click.UsageError('Please specify the AWS region on the command line (--region) or in ~/.aws/config')
+        raise click.UsageError('Please specify the AWS region on the '
+                               'command line (--region) or in ~/.aws/config')
 
-    # FIXME bool(boto3.client('cloudformation', 'moon-1')) == True
-    cf = boto3.client('cloudformation', region)
-    if not cf:
-        raise click.UsageError('Invalid region "{}"'.format(region))
     return region
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -281,3 +281,12 @@ def boto_resource(monkeypatch):
         return MagicMock()
 
     monkeypatch.setattr('boto3.resource', my_resource)
+
+
+@pytest.fixture(autouse=True)
+def valid_regions(monkeypatch):
+    m_session = MagicMock()
+    m_session.return_value = m_session
+    m_session.get_available_regions.return_value = ['aa-fakeregion-1']
+    monkeypatch.setattr('boto3.session.Session', m_session)
+    return m_session

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,8 @@ from senza.subcommands.root import cli
 from senza.traffic import PERCENT_RESOLUTION, StackVersion
 
 from fixtures import (HOSTED_ZONE_EXAMPLE_NET,  # noqa: F401
-                      HOSTED_ZONE_EXAMPLE_ORG, boto_client, boto_resource)
+                      HOSTED_ZONE_EXAMPLE_ORG, boto_client, boto_resource,
+                      valid_regions)
 
 
 def test_invalid_definition():
@@ -190,7 +191,7 @@ def test_region_validation(monkeypatch):
                                catch_exceptions=False)
 
     assert ('Error: Invalid value for "--region": \'invalid-region\'. '
-            'Region must be a valid AWS region.' in result.output)
+            'Region must be one of the following AWS regions:' in result.output)
 
 
 def test_print_replace_mustache(monkeypatch):


### PR DESCRIPTION
Use [`boto3.session.Session.get_available_regions('cloudformation')`](http://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.get_available_regions) to get all valid AWS regions.