### PR TITLE
Improve senza/utils.py based on pylint

### DIFF
--- a/senza/utils.py
+++ b/senza/utils.py
@@ -19,7 +19,7 @@ def ensure_keys(dict_obj, *keys):
     """
     Ensure ``dict_obj`` has the hierarchy ``{keys[0]: {keys[1]: {...}}}``
 
-    The inner most key will have ``{}`` has value if didn't exist already.
+    The innermost key will have ``{}`` has value if didn't exist already.
     """
     if len(keys) == 0:
         return dict_obj

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -35,7 +35,10 @@ def camel_case_to_underscore(name):
     """
     Converts name from CamelCase to snake_case
     """
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+    # the two steps are needed to support words with sequences of more than
+    # one uppercase character
+    step1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', step1).lower()
 
 
 def pystache_render(*args, **kwargs):

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -1,12 +1,26 @@
+"""
+Random functions that are useful in several places and not don't fall under
+the domain of any other module.
+"""
+
 import re
 import pystache
 
 
-def named_value(d):
-    return next(iter(d.items()))
+def named_value(dictionary):
+    """
+    Gets the name and value of a dict with a single key (for example SenzaInfo
+    parameters or Senza Components)
+    """
+    return next(iter(dictionary.items()))
 
 
 def ensure_keys(dict_obj, *keys):
+    """
+    Ensure ``dict_obj`` has the hierarchy ``{keys[0]: {keys[1]: {...}}}``
+
+    The inner most key will have ``{}`` has value if didn't exist already.
+    """
     if len(keys) == 0:
         return dict_obj
     else:
@@ -21,10 +35,12 @@ def camel_case_to_underscore(name):
     """
     Converts name from CamelCase to snake_case
     """
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
 
 
 def pystache_render(*args, **kwargs):
+    """
+    Render pystache template with strict mode
+    """
     render = pystache.Renderer(missing_tags='strict')
     return render.render(*args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,3 +3,5 @@ from senza.utils import camel_case_to_underscore
 
 def test_camel_case_to_underscore():
     assert camel_case_to_underscore('CamelCaseToUnderscore') == 'camel_case_to_underscore'
+    assert camel_case_to_underscore('ThisIsABook') == 'this_is_a_book'
+    assert camel_case_to_underscore('InstanceID') == 'instance_id'


### PR DESCRIPTION
- Docstrings;
- Argument name changed in `named_value` (still not really better);
- Removed one step from `camel_case_to_underscore` (@hjacobs I couldn't find any case that failed without it but maybe I'm missing something can you check this change?)