### PR TITLE
Allow scale down/up specific values for ScaleAdjustment and Cooldown

### DIFF
--- a/examples/autoscaling.yaml
+++ b/examples/autoscaling.yaml
@@ -32,11 +32,20 @@ SenzaComponents:
         # default instance count is 1
         # default timeout is 15 minutes
         SuccessRequires: "2 within 5m"
-        # scale two instances up/down at a time
+        # scale two instances up/down at a time (if not overwritten by scale up/down specififc value)
         ScalingAdjustment: 2
+        # scale three instances up at a time (if set, it overwrites the ScalingAdjustment value for scaling up)
+        ScalingUpAdjustment: 3
+        # scale one instance down at a time (if set, it overwrites the ScalingAdjustment value for scaling down)
+        ScalingUpAdjustment: 1
         # after scaling, suspend further scaling activities
         # for 30 minutes (1800 seconds)
+        # Can be overwritten by scale up/down specific values
         Cooldown: 1800
+        # If set it overwrites the Cooldown value for scaling up
+        ScaleUpCooldown: 300
+        # If set it overwrites the Cooldown value for scaling down
+        ScaleDownCooldown: 3600
         # time over which the threshold is measured in seconds
         Period: 300
         # how many periods the threshold must be hit before scaling

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -175,14 +175,17 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
         asg_properties["MinSize"] = as_conf["Minimum"]
         asg_properties["DesiredCapacity"] = max(int(as_conf["Minimum"]), int(as_conf.get('DesiredCapacity', 1)))
 
-        scaling_adjustment = int(as_conf.get("ScalingAdjustment", 1))
+        default_scaling_adjustment = as_conf.get("ScalingAdjustment", 1)
+        default_cooldown = as_conf.get("Cooldown", "60")
+
         # ScaleUp policy
+        scaling_up_adjustment = int(as_conf.get("ScalingUpAdjustment", default_scaling_adjustment))
         definition["Resources"][asg_name + "ScaleUp"] = {
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": str(scaling_adjustment),
-                "Cooldown": str(as_conf.get("Cooldown", "60")),
+                "ScalingAdjustment": str(scaling_up_adjustment),
+                "Cooldown": str(as_conf.get("ScaleUpCooldown", default_cooldown)),
                 "AutoScalingGroupName": {
                     "Ref": asg_name
                 }
@@ -190,12 +193,13 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
         }
 
         # ScaleDown policy
+        scaling_down_adjustment = int(as_conf.get("ScalingDownAdjustment", default_scaling_adjustment))
         definition["Resources"][asg_name + "ScaleDown"] = {
             "Type": "AWS::AutoScaling::ScalingPolicy",
             "Properties": {
                 "AdjustmentType": "ChangeInCapacity",
-                "ScalingAdjustment": str((-1) * scaling_adjustment),
-                "Cooldown": str(as_conf.get("Cooldown", "60")),
+                "ScalingAdjustment": str((-1) * scaling_down_adjustment),
+                "Cooldown": str(as_conf.get("ScaleDownCooldown", default_cooldown)),
                 "AutoScalingGroupName": {
                     "Ref": asg_name
                 }

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -524,7 +524,10 @@ def test_component_auto_scaling_group_configurable_properties():
             'ScaleUpThreshold': 50,
             'ScaleDownThreshold': 20,
             'EvaluationPeriods': 1,
+            'ScalingAdjustment': 1,
+            'ScalingUpAdjustment': 3,
             'Cooldown': 30,
+            'ScaleDownCooldown': 360,
             'Statistic': 'Maximum'
         }
     }
@@ -541,12 +544,12 @@ def test_component_auto_scaling_group_configurable_properties():
 
     assert result["Resources"]["FooScaleUp"] is not None
     assert result["Resources"]["FooScaleUp"]["Properties"] is not None
-    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == "1"
+    assert result["Resources"]["FooScaleUp"]["Properties"]["ScalingAdjustment"] == "3"
     assert result["Resources"]["FooScaleUp"]["Properties"]["Cooldown"] == "30"
 
     assert result["Resources"]["FooScaleDown"] is not None
     assert result["Resources"]["FooScaleDown"]["Properties"] is not None
-    assert result["Resources"]["FooScaleDown"]["Properties"]["Cooldown"] == "30"
+    assert result["Resources"]["FooScaleDown"]["Properties"]["Cooldown"] == "360"
     assert result["Resources"]["FooScaleDown"]["Properties"]["ScalingAdjustment"] == "-1"
 
     assert result["Resources"]["Foo"] is not None


### PR DESCRIPTION
Right now in the team we often define the CloudWatch::Alarm and AutoScaling::ScalingPolicy manually in the senza file, not using the senza provided properties, to have different values for scaling up and down. For instance, I often want to scale up much quicker and with more instances than scaling down.