### PR TITLE
Show helpful error if dns.resolver import fails

### DIFF
--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -4,8 +4,7 @@ from typing import Dict, Iterator
 
 import boto3
 import click
-import dns.resolver
-from clickclick import Action, action, ok, print_table, warning
+from clickclick import Action, action, fatal_error, ok, print_table, warning
 
 from .aws import StackReference, get_stacks, get_tag
 from .manaus import ClientError
@@ -15,6 +14,12 @@ from .manaus.exceptions import ELBNotFound, StackNotFound, StackNotUpdated
 from .manaus.route53 import (RecordType, Route53, Route53HostedZone,
                              convert_cname_records_to_alias)
 from .manaus.utils import extract_client_error_code
+
+try:
+    import dns.resolver
+except ImportError:
+    fatal_error("Failed to import dns.resolver.\n"
+                "Make sure you have dnspython installed and updated.")
 
 PERCENT_RESOLUTION = 2
 FULL_PERCENTAGE = PERCENT_RESOLUTION * 100

--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -19,7 +19,7 @@ try:
     import dns.resolver
 except ImportError:
     fatal_error("Failed to import dns.resolver.\n"
-                "Make sure you have dnspython installed and updated.")
+                "Run 'pip3 install -U --force-reinstall dnspython'.")
 
 PERCENT_RESOLUTION = 2
 FULL_PERCENTAGE = PERCENT_RESOLUTION * 100

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -119,5 +119,5 @@ def test_dns_import(monkeypatch):
     monkeypatch.setattr('clickclick.fatal_error', m_fatal_error)
     importlib.reload(senza.traffic)
     m_fatal_error.assert_called_once_with("Failed to import dns.resolver.\n"
-                                          "Make sure you have dnspython "
-                                          "installed and updated.")
+                                          "Run 'pip3 install -U "
+                                          "--force-reinstall dnspython'.")

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -1,6 +1,9 @@
+import builtins
+import importlib
 from unittest.mock import MagicMock
 
 import botocore.exceptions
+import senza.traffic
 from senza.aws import SenzaStackSummary
 from senza.manaus.route53 import RecordType
 from senza.traffic import (StackVersion, get_stack_versions, get_weights,
@@ -99,3 +102,22 @@ def test_resolve_to_ip_addresses(monkeypatch):
     query.side_effect = None
     query.return_value = [MagicMock(address='1.2.3.4')]
     assert resolve_to_ip_addresses('example.org') == {'1.2.3.4'}
+
+
+def test_dns_import(monkeypatch):
+    realimport = builtins.__import__
+
+    def fake_import(name: str, *args, **kwargs):
+        if name == 'dns':
+            raise ImportError()
+        else:
+            m = realimport(name, *args, **kwargs)
+            return m
+
+    monkeypatch.setattr(builtins, '__import__', fake_import)
+    m_fatal_error = MagicMock()
+    monkeypatch.setattr('clickclick.fatal_error', m_fatal_error)
+    importlib.reload(senza.traffic)
+    m_fatal_error.assert_called_once_with("Failed to import dns.resolver.\n"
+                                          "Make sure you have dnspython "
+                                          "installed and updated.")


### PR DESCRIPTION
I'm singling out this import since it's the only import error I saw on Sentry and there are already multiple reports from multiple hosts.