### PR TITLE
allow specifying both ELBv2 and ELBv1 for the same ASG (e.g. HTTPS AL…

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -156,7 +156,7 @@ def component_auto_scaling_group(definition, configuration, args, info, force, a
             asg_properties["LoadBalancerNames"] = [{'Ref': ref} for ref in configuration["ElasticLoadBalancer"]]
         # use ELB health check by default
         default_health_check_type = 'ELB'
-    elif "ElasticLoadBalancerV2" in configuration:
+    if "ElasticLoadBalancerV2" in configuration:
         if isinstance(configuration["ElasticLoadBalancerV2"], str):
             asg_properties["TargetGroupARNs"] = [{"Ref": configuration["ElasticLoadBalancerV2"] + 'TargetGroup'}]
         elif isinstance(configuration["ElasticLoadBalancerV2"], list):


### PR DESCRIPTION
This allows using both an ELBv2 ("ALB", application load balancer) and a "classic" ELB with the same ASG.

The ALB only supports HTTP/HTTPS and can therefore not be used in certain situations (e.g. with SSL client certs), i.e. users might want to attach an additional TCP "classic" ELB at the same time.