### PR TITLE
use dnspython instead of deprecated dnspython3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 clickclick>=1.0
 pystache
 PyYAML
-dnspython3
+dnspython>=1.15.0
 stups-pierone>=1.0.34
 boto3>=1.3.0
 botocore>=1.4.10


### PR DESCRIPTION
dnspython3 has been superseded by the regular dnspython kit, which now supports both Python 2 and Python 3.