### PR TITLE
Ability to place a stack into maintenance mode #443

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1515,10 +1515,11 @@ def test_maintenance(monkeypatch):
   monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
 
   runner = CliRunner()
-  result = runner.invoke(cli, ['maintenance', 'myapp', '1', '--region=aa-fakeregion-1'],
+  result = runner.invoke(cli, ['maintenance', 'myapp', '1', 'false', '--region=aa-fakeregion-1'],
                          catch_exceptions=False)
 
   assert 'Changing maintenance mode on Auto Scaling Group' in result.output
+  assert 'Maintance mode set to False' in result.output
 
 def test_patch(monkeypatch):
     boto3 = MagicMock()


### PR DESCRIPTION
Given a stack it will detect all asgs within that stack negates the tag named 'maintenance' and do the same on all instances currently belonging to that asg.

$ senza maintenance some-stack-name
Changing maintenance mode on Auto Scaling Group some-stack-name-version-AppServer-1R2KFL5HLI5NT..
Maintance mode set to False for some-stack-name-version-AppServer-1R2KFL5HLI5NT

$ senza maintenance some-stack-name
Changing maintenance mode on Auto Scaling Group some-stack-name-version-AppServer-1R2KFL5HLI5NT..
Maintance mode set to True for some-stack-name-version-AppServer-1R2KFL5HLI5NT

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>