### PR TITLE
Exporting ApplicationName as an AWS tag for ELBs

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -4,6 +4,8 @@ from senza.aws import resolve_security_groups
 from senza.definitions import AccountArguments
 
 from ..cli import TemplateArguments
+from ..utils import extract_attribute
+
 from ..manaus import ClientError
 from ..manaus.acm import ACM, ACMCertificate
 from ..manaus.iam import IAM, IAMServerCertificate
@@ -104,6 +106,7 @@ def component_elastic_load_balancer(definition,
                                     info: dict,
                                     force,
                                     account_info: AccountArguments):
+
     lb_name = configuration["Name"]
     # domains pointing to the load balancer
     subdomain = ''
@@ -210,6 +213,15 @@ def component_elastic_load_balancer(definition,
             ]
         }
     }
+
+    application_name = extract_attribute(definition, 'ApplicationName')
+
+    if application_name:
+        definition["Resources"][lb_name]["Properties"]["Tags"].append({
+            "Key": "ApplicationName",
+            "Value": application_name
+        })
+
     for key, val in configuration.items():
         # overwrite any specified properties, but
         # ignore our special Senza properties as they are not supported by CF

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -4,6 +4,7 @@ from senza.components.elastic_load_balancer import (ALLOWED_LOADBALANCER_SCHEMES
                                                     get_load_balancer_name,
                                                     get_ssl_cert)
 from senza.definitions import AccountArguments
+from ..utils import extract_attribute
 
 from ..cli import TemplateArguments
 from ..manaus.route53 import convert_cname_records_to_alias
@@ -115,6 +116,14 @@ def component_elastic_load_balancer_v2(definition,
             "Value": info["StackVersion"]
         }
     ]
+
+    application_name = extract_attribute(definition, 'ApplicationName')
+
+    if application_name:
+        tags.append({
+            "Key": "ApplicationName",
+            "Value": application_name
+        })
 
     # load balancer
     definition["Resources"][lb_name] = {

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -47,3 +47,18 @@ def pystache_render(*args, **kwargs):
     """
     render = pystache.Renderer(missing_tags='strict')
     return render.render(*args, **kwargs)
+
+
+def extract_attribute(definition: dict, attr_name: str):
+    """
+    Extracts an attribute `attr_name` from `SenzaInfo` section from a
+    senza-definition .yaml file.
+
+    :param definition: Definition parsed from the .yaml file.
+    :param attr_name: Name of the attribute to be extracted.
+    :return: Value of the attribute `attr_name` if provided otherwise None.
+    """
+
+    mappings = definition.get('Mappings', {})
+    attr_value = mappings.get('Senza', {}).get('Info', {}).get(attr_name)
+    return attr_value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1966,7 +1966,7 @@ def test_application_name_tag_for_load_balancer(monkeypatch,
     # attribute is put into 'Mappings' by default from the .yaml file
     assert data['Mappings']['Senza']['Info']['ApplicationName'] == 'SenzaApp'
 
-    # ApplicationName is saved as a tag for ELBs
+    # ApplicationName is saved as a tag for the ELB
     tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
     assert {'Key': 'ApplicationName', 'Value': 'SenzaApp'} in tags
 
@@ -2019,7 +2019,7 @@ def test_application_name_tag_for_load_balancer_v2(monkeypatch,
     # attribute is put into 'Mappings' by default from the .yaml file
     assert data['Mappings']['Senza']['Info']['ApplicationName'] == 'SenzaApp'
 
-    # ApplicationName is saved as a tag for ELBs
+    # ApplicationName is saved as a tag for the ELBv2
     tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
     assert {'Key': 'ApplicationName', 'Value': 'SenzaApp'} in tags
 
@@ -2072,6 +2072,6 @@ def test_random_attribute_not_exported_as_tag(monkeypatch,
     # attribute is put into 'Mappings' by default from the .yaml file
     assert data['Mappings']['Senza']['Info']['RandomAttribute123'] == 'SenzaApp'
 
-    # ApplicationName is saved as a tag for ELBs
+    # RandomAttribute123 is not saved as a tag for ELBs
     tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
     assert {'Key': 'RandomAttribute123', 'Value': 'SenzaApp'} not in tags

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,6 @@ import os
 from contextlib import contextmanager
 
 from typing import List, Dict
-from typing import Optional
 from unittest.mock import MagicMock, mock_open
 
 import botocore.exceptions
@@ -1917,3 +1916,162 @@ def test_create_cf_template_compact_json(monkeypatch):
     cf_template = create_cf_template(definition, 'aa-fakeregion-1', '1', [], False, None)
     # verify that we are using the "compressed" JSON format (no indentation, no extra whitespace)
     assert '"Senza":{"Info":' in cf_template['TemplateBody']
+
+
+def test_application_name_tag_for_load_balancer(monkeypatch,
+                                                boto_client,
+                                                boto_resource,
+                                                disable_version_check):
+    senza.traffic.DNS_ZONE_CACHE = {}
+
+    data = {'SenzaInfo': {'StackName': 'test',
+                          'OperatorTopicId': 'mytopic',
+                          'Parameters': [
+                              {'ImageVersion': {'Description': ''}}]},
+            'SenzaComponents': [
+                {'Configuration': {'Type': 'Senza::StupsAutoConfiguration'}},
+                {'AppServer': {'Type': 'Senza::TaupageAutoScalingGroup',
+                               'ElasticLoadBalancer': 'AppLoadBalancer',
+                               'InstanceType': 't2.micro',
+                               'TaupageConfig': {'runtime': 'Docker',
+                                                 'source': 'foo/bar:{{Arguments.ImageVersion}}'},
+                               'IamRoles': [{'Stack': 'stack1',
+                                             'LogicalId': 'ReferencedRole'}],
+                               'SecurityGroups': ['app-sg', 'sg-123'],
+                               'AutoScaling':
+                                   {'Minimum': 1,
+                                    'Maximum': 10,
+                                    'MetricType': 'CPU'}}},
+                {'AppLoadBalancer': {
+                    'Type': 'Senza::WeightedDnsElasticLoadBalancer',
+                    'HTTPPort': 8080,
+                    'SecurityGroups': ['app-sg']}}]}
+
+    data['SenzaInfo']['ApplicationName'] = 'SenzaApp'
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+
+        result = runner.invoke(cli,
+                               ['print', 'myapp.yaml', '--region=aa-fakeregion-1', '123', '1.0-SNAPSHOT'],
+                               catch_exceptions=False)
+    # no stdout/stderr seperation with runner.invoke...
+    stdout, cfjson = result.output.split('\n', 1)
+    assert 'Generating Cloud Formation template.. OK' == stdout
+    data = json.loads(cfjson)
+
+    # attribute is put into 'Mappings' by default from the .yaml file
+    assert data['Mappings']['Senza']['Info']['ApplicationName'] == 'SenzaApp'
+
+    # ApplicationName is saved as a tag for ELBs
+    tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
+    assert {'Key': 'ApplicationName', 'Value': 'SenzaApp'} in tags
+
+
+def test_application_name_tag_for_load_balancer_v2(monkeypatch,
+                                                   boto_client,
+                                                   boto_resource,
+                                                   disable_version_check):
+    senza.traffic.DNS_ZONE_CACHE = {}
+
+    data = {'SenzaInfo': {'StackName': 'test',
+                          'OperatorTopicId': 'mytopic',
+                          'Parameters': [
+                              {'ImageVersion': {'Description': ''}}]},
+            'SenzaComponents': [
+                {'Configuration': {'Type': 'Senza::StupsAutoConfiguration'}},
+                {'AppServer': {'Type': 'Senza::TaupageAutoScalingGroup',
+                               'ElasticLoadBalancer': 'AppLoadBalancer',
+                               'InstanceType': 't2.micro',
+                               'TaupageConfig': {'runtime': 'Docker',
+                                                 'source': 'foo/bar:{{Arguments.ImageVersion}}'},
+                               'IamRoles': [{'Stack': 'stack1',
+                                             'LogicalId': 'ReferencedRole'}],
+                               'SecurityGroups': ['app-sg', 'sg-123'],
+                               'AutoScaling':
+                                   {'Minimum': 1,
+                                    'Maximum': 10,
+                                    'MetricType': 'CPU'}}},
+                {'AppLoadBalancer': {
+                    'Type': 'Senza::WeightedDnsElasticLoadBalancerV2',
+                    'HTTPPort': 8080,
+                    'SecurityGroups': ['app-sg']}}]}
+
+    data['SenzaInfo']['ApplicationName'] = 'SenzaApp'
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+
+        result = runner.invoke(cli,
+                               ['print', 'myapp.yaml', '--region=aa-fakeregion-1', '123', '1.0-SNAPSHOT'],
+                               catch_exceptions=False)
+    # no stdout/stderr seperation with runner.invoke...
+    stdout, cfjson = result.output.split('\n', 1)
+    assert 'Generating Cloud Formation template.. OK' == stdout
+    data = json.loads(cfjson)
+
+    # attribute is put into 'Mappings' by default from the .yaml file
+    assert data['Mappings']['Senza']['Info']['ApplicationName'] == 'SenzaApp'
+
+    # ApplicationName is saved as a tag for ELBs
+    tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
+    assert {'Key': 'ApplicationName', 'Value': 'SenzaApp'} in tags
+
+
+def test_random_attribute_not_exported_as_tag(monkeypatch,
+                                              boto_client,
+                                              boto_resource,
+                                              disable_version_check):
+    senza.traffic.DNS_ZONE_CACHE = {}
+
+    data = {'SenzaInfo': {'StackName': 'test',
+                          'OperatorTopicId': 'mytopic',
+                          'Parameters': [
+                              {'ImageVersion': {'Description': ''}}]},
+            'SenzaComponents': [
+                {'Configuration': {'Type': 'Senza::StupsAutoConfiguration'}},
+                {'AppServer': {'Type': 'Senza::TaupageAutoScalingGroup',
+                               'ElasticLoadBalancer': 'AppLoadBalancer',
+                               'InstanceType': 't2.micro',
+                               'TaupageConfig': {'runtime': 'Docker',
+                                                 'source': 'foo/bar:{{Arguments.ImageVersion}}'},
+                               'IamRoles': [{'Stack': 'stack1',
+                                             'LogicalId': 'ReferencedRole'}],
+                               'SecurityGroups': ['app-sg', 'sg-123'],
+                               'AutoScaling':
+                                   {'Minimum': 1,
+                                    'Maximum': 10,
+                                    'MetricType': 'CPU'}}},
+                {'AppLoadBalancer': {
+                    'Type': 'Senza::WeightedDnsElasticLoadBalancerV2',
+                    'HTTPPort': 8080,
+                    'SecurityGroups': ['app-sg']}}]}
+
+    data['SenzaInfo']['RandomAttribute123'] = 'SenzaApp'
+
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        with open('myapp.yaml', 'w') as fd:
+            yaml.dump(data, fd)
+
+        result = runner.invoke(cli,
+                               ['print', 'myapp.yaml', '--region=aa-fakeregion-1', '123', '1.0-SNAPSHOT'],
+                               catch_exceptions=False)
+    # no stdout/stderr seperation with runner.invoke...
+    stdout, cfjson = result.output.split('\n', 1)
+    assert 'Generating Cloud Formation template.. OK' == stdout
+    data = json.loads(cfjson)
+
+    # attribute is put into 'Mappings' by default from the .yaml file
+    assert data['Mappings']['Senza']['Info']['RandomAttribute123'] == 'SenzaApp'
+
+    # ApplicationName is saved as a tag for ELBs
+    tags = data['Resources']['AppLoadBalancer']['Properties']['Tags']
+    assert {'Key': 'RandomAttribute123', 'Value': 'SenzaApp'} not in tags

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,37 @@
-from senza.utils import camel_case_to_underscore
+from senza.utils import camel_case_to_underscore, extract_attribute
 
 
 def test_camel_case_to_underscore():
     assert camel_case_to_underscore('CamelCaseToUnderscore') == 'camel_case_to_underscore'
     assert camel_case_to_underscore('ThisIsABook') == 'this_is_a_book'
     assert camel_case_to_underscore('InstanceID') == 'instance_id'
+
+
+def test_extract_attribute_that_is_set():
+    definition = {
+        'Mappings': {
+            'Senza': {
+                'Info': {
+                    'ApplicationName': 'SenzaApp'
+                }
+            }
+        }
+    }
+    assert extract_attribute(definition, 'ApplicationName') == 'SenzaApp'
+
+
+def test_extract_attribute_that_is_not_set():
+    definition = {
+        'Mappings': {
+            'Senza': {
+                'Info': {
+                }
+            }
+        }
+    }
+    assert extract_attribute(definition, 'ApplicationName') is None
+
+
+def test_extract_attribute_empty_definition():
+    definition = {}
+    assert extract_attribute(definition, 'ApplicationName') is None


### PR DESCRIPTION
I added a way to export `ApplicationName` attribute in `SenzaInfo` section as an AWS tag for the ELB.

More info: #451 