### PR TITLE
Capabilities parameter does not accept None as value

### DIFF
--- a/senza/manaus/cloudformation.py
+++ b/senza/manaus/cloudformation.py
@@ -191,7 +191,7 @@ class CloudFormationStack:
             client.update_stack(StackName=self.name,
                                 TemplateBody=json.dumps(self.template),
                                 Parameters=parameters,
-                                Capabilities=self.capabilities)
+                                Capabilities=self.capabilities or [])
         except ClientError as err:
             response = err.response
             error_info = response['Error']


### PR DESCRIPTION
Fixes #456 

Capabilities parameter is optional for certain types of CF stack, but does not accept `None` as value.

https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html