### PR TITLE
Refactored get_load_balancer_name to be used when getting stack health

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -49,7 +49,7 @@ from .templates import get_template_description, get_templates
 from .traffic import (change_version_traffic, get_records,
                       print_version_traffic, resolve_to_ip_addresses)
 from .utils import (camel_case_to_underscore, ensure_keys, named_value,
-                    pystache_render)
+                    pystache_render, get_load_balancer_name)
 
 STYLES = {
     'RUNNING': {'fg': 'green'},
@@ -532,7 +532,7 @@ def health(region, stack_ref, all, output, w, watch):
                 alb_id = ''.join([d['Value'] for d in metric['Dimensions'] if d['Name'] == 'LoadBalancer'])
                 alb_ids[alb_id.split('/')[1]] = alb_id
         for stack in get_stacks(stack_refs, region, all=all):
-            lb_name = stack.StackName
+            lb_name = get_load_balancer_name(stack_name=stack.name, stack_version=stack.version)
             instance_health = get_instance_health(lb_name, region)
             row = {
                 'stack_name': stack.name,

--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -2,6 +2,7 @@ import click
 from clickclick import fatal_error
 from senza.aws import resolve_security_groups
 from senza.definitions import AccountArguments
+from senza.utils import get_load_balancer_name
 
 from ..cli import TemplateArguments
 from ..manaus import ClientError
@@ -13,16 +14,6 @@ SENZA_PROPERTIES = frozenset(['Domains', 'HealthCheckPath', 'HealthCheckPort', '
                               'HTTPPort', 'Name', 'SecurityGroups', 'SSLCertificateId', 'Type'])
 ALLOWED_HEALTH_CHECK_PROTOCOLS = frozenset(["HTTP", "TCP", "UDP", "SSL"])
 ALLOWED_LOADBALANCER_SCHEMES = frozenset(["internet-facing", "internal"])
-
-
-def get_load_balancer_name(stack_name: str, stack_version: str):
-    """
-    Returns the name of the load balancer for the stack name and version,
-    truncating the name if necessary.
-    """
-    # Loadbalancer name cannot exceed 32 characters, try to shorten
-    l = 32 - len(stack_version) - 1
-    return '{}-{}'.format(stack_name[:l], stack_version)
 
 
 def get_ssl_cert(subdomain, main_zone, configuration, account_info: AccountArguments):

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -47,3 +47,13 @@ def pystache_render(*args, **kwargs):
     """
     render = pystache.Renderer(missing_tags='strict')
     return render.render(*args, **kwargs)
+
+
+def get_load_balancer_name(stack_name: str, stack_version: str):
+    """
+    Returns the name of the load balancer for the stack name and version,
+    truncating the name if necessary.
+    """
+    # Loadbalancer name cannot exceed 32 characters, try to shorten
+    l = 32 - len(stack_version) - 1
+    return '{}-{}'.format(stack_name[:l], stack_version)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,13 @@
-from senza.utils import camel_case_to_underscore
+from senza.utils import camel_case_to_underscore, get_load_balancer_name
 
 
 def test_camel_case_to_underscore():
     assert camel_case_to_underscore('CamelCaseToUnderscore') == 'camel_case_to_underscore'
     assert camel_case_to_underscore('ThisIsABook') == 'this_is_a_book'
     assert camel_case_to_underscore('InstanceID') == 'instance_id'
+
+
+def test_get_load_balancer_name():
+    assert get_load_balancer_name(stack_name='really-long-application-name',
+                                  stack_version='cd871c54') == 'really-long-application-cd871c54'
+    assert get_load_balancer_name(stack_name='app-name', stack_version='1') == 'app-name-1'


### PR DESCRIPTION
Currently when getting stack health through `senza health` the LB metrics cannot be fetched for stacks with long application names. This is because the application name is truncated when creating the load balancer. However in the `health` command the name truncation is not performed which means the metrics are not fetched correctly. This PR moves the truncation function to the `utils` package so that it can be used in the `cli` module as well as the `elb` module.