### PR TITLE
Proper error if parameter file is empty

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -34,7 +34,7 @@ from .components import evaluate_template, get_component
 from .components.stups_auto_configuration import find_taupage_image
 from .definitions import AccountArguments
 from .error_handling import HandleExceptions
-from .exceptions import InvalidDefinition
+from .exceptions import InvalidDefinition, InvalidParameterFile
 from .manaus.boto_proxy import BotoClientProxy
 from .manaus.cloudformation import CloudFormation
 from .manaus.exceptions import VPCError
@@ -310,6 +310,9 @@ def read_parameter_file(parameter_file):
 
     try:
         cfg = yaml.safe_load(response.read())
+        if cfg is None:
+            raise InvalidParameterFile(parameter_file,
+                                       'Parameter file is empty')
         for key, val in cfg.items():
             paras.append("{}={}".format(key, val))
     except yaml.YAMLError as e:

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -95,7 +95,7 @@ class HandleExceptions:
         elif sentry:
             die_fatal_error("Unknown Error: {e}.\n"
                             "This error will be pushed to sentry ".format(
-                e=unknown_exception))
+                                e=unknown_exception))
         elif not sentry:
             file_name = store_exception(unknown_exception)
             die_fatal_error('Unknown Error: {e}.\n'

--- a/senza/error_handling.py
+++ b/senza/error_handling.py
@@ -8,15 +8,16 @@ from tempfile import NamedTemporaryFile
 from traceback import format_exception
 from typing import Optional  # noqa: F401
 
-import senza
 import yaml.constructor
 from botocore.exceptions import ClientError, NoCredentialsError
 from clickclick import fatal_error
 from raven import Client
 
+import senza
 from .configuration import configuration
 from .exceptions import (InvalidDefinition, InvalidUserDataType,
-                         PiuNotFound, SecurityGroupNotFound)
+                         PiuNotFound, SecurityGroupNotFound,
+                         InvalidParameterFile)
 from .manaus.exceptions import (ELBNotFound, HostedZoneNotFound, InvalidState,
                                 RecordNotFound)
 from .manaus.utils import extract_client_error_code
@@ -33,7 +34,8 @@ def store_exception(exception: Exception) -> str:
 
     content = ''.join(tracebacks)
 
-    with NamedTemporaryFile(prefix="senza-traceback-", delete=False) as error_file:
+    with NamedTemporaryFile(prefix="senza-traceback-",
+                            delete=False) as error_file:
         file_name = error_file.name
         error_file.write(content.encode())
 
@@ -92,7 +94,8 @@ class HandleExceptions:
             raise unknown_exception
         elif sentry:
             die_fatal_error("Unknown Error: {e}.\n"
-                            "This error will be pushed to sentry ".format(e=unknown_exception))
+                            "This error will be pushed to sentry ".format(
+                e=unknown_exception))
         elif not sentry:
             file_name = store_exception(unknown_exception)
             die_fatal_error('Unknown Error: {e}.\n'
@@ -135,7 +138,8 @@ class HandleExceptions:
                 "{}\nYou can install piu with the following command:"
                 "\nsudo pip3 install --upgrade stups-piu".format(error))
         except (ELBNotFound, HostedZoneNotFound, RecordNotFound,
-                InvalidDefinition, InvalidState, InvalidUserDataType) as error:
+                InvalidDefinition, InvalidState, InvalidUserDataType,
+                InvalidParameterFile) as error:
             die_fatal_error(error)
         except SecurityGroupNotFound as error:
             message = ("{}\nRun `senza init` to (re-)create "
@@ -160,4 +164,5 @@ def setup_sentry(sentry_endpoint: Optional[str]):
     return sentry_client
 
 
-sentry = setup_sentry(configuration.get('sentry.endpoint'))  # pylint: disable=locally-disabled, invalid-name
+sentry = setup_sentry(configuration.get(
+    'sentry.endpoint'))  # pylint: disable=locally-disabled, invalid-name

--- a/senza/exceptions.py
+++ b/senza/exceptions.py
@@ -31,7 +31,7 @@ class InvalidConfigKey(SenzaException, ValueError):
 
 class InvalidDefinition(SenzaException):
     """
-    Exception raised when trying to parse and invalid senza definition
+    Exception raised when trying to parse an invalid senza definition
     """
 
     def __init__(self, path: str, reason: str):
@@ -40,6 +40,20 @@ class InvalidDefinition(SenzaException):
 
     def __str__(self):
         return ("{path} is not a valid senza definition: "
+                "{reason}".format_map(vars(self)))
+
+
+class InvalidParameterFile(SenzaException):
+    """
+    Exception raised when trying to parse an invalid parameter
+    """
+
+    def __init__(self, path: str, reason: str):
+        self.path = path
+        self.reason = reason
+
+    def __str__(self):
+        return ("{path} is not a valid parameter: "
                 "{reason}".format_map(vars(self)))
 
 


### PR DESCRIPTION
If a parameter file is empty senza will currently raise the following exception:

```
AttributeError: 'NoneType' object has no attribute 'items'
```