### PR TITLE
Allow filtering of fields returned by senza list

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -403,9 +403,10 @@ def all_with_version(stack_refs: list):
 @watch_option
 @watchrefresh_option
 @click.option('--all', is_flag=True, help='Show all stacks, including deleted ones')
+@click.option('--field', '-f', metavar='NAME', multiple=True, help='Specify field to be returned')
 @click.argument('stack_ref', nargs=-1)
 @stacktrace_visible_option
-def list_stacks(region, stack_ref, all, output, w, watch):
+def list_stacks(region, stack_ref, all, output, field, w, watch):
     '''List Cloud Formation stacks'''
 
     region = get_region(region)
@@ -424,9 +425,13 @@ def list_stacks(region, stack_ref, all, output, w, watch):
 
         rows.sort(key=lambda x: (x['stack_name'], x['version']))
 
+        columns = ['stack_name', 'version', 'status', 'creation_time', 'description']
+
+        if field:
+            columns = [column for column in columns if column in field]
+
         with OutputFormat(output):
-            print_table('stack_name version status creation_time description'.split(), rows,
-                        styles=STYLES, titles=TITLES)
+            print_table(columns, rows, styles=STYLES, titles=TITLES)
 
 
 def get_application_load_balancer_metrics(cloudwatch, alb_id, start, now):


### PR DESCRIPTION
Right now `senza list` returns a fixed list of fields for each stack. There're use cases where I might only need some of them, e.g. `version`.

I'm proposing to add `--field` option which would allow to specify which field to include in the output:

```bash
$ senza list -o tsv my-stack --field version
version
1
```

It's possible to specify parameter multiple times in the command line if more parameters needed:

```bash
$ senza list -o tsv my-stack --field version --field stack_name
stack_name      version
my-stack        1
```

If no `--field` parameter specified, the tool will output all fields as before:

```bash
$ senza list -o tsv my-stack
stack_name      version status  creation_time   description
my-stack        1       UPDATE_COMPLETE 7h ago  My Stack
```
