### PR TITLE
Check if LoadBalancerName is set

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -2,7 +2,7 @@ import click
 from clickclick import fatal_error
 from senza.aws import resolve_security_groups
 from senza.definitions import AccountArguments
-from senza.utils import get_load_balancer_name
+from senza.utils import (get_load_balancer_name, generate_valid_cloud_name)
 
 from ..cli import TemplateArguments
 from ..manaus import ClientError

--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -2,7 +2,7 @@ import click
 from clickclick import fatal_error
 from senza.aws import resolve_security_groups
 from senza.definitions import AccountArguments
-from senza.utils import (get_load_balancer_name, generate_valid_cloud_name)
+from senza.utils import get_load_balancer_name
 
 from ..cli import TemplateArguments
 from ..manaus import ClientError

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -3,7 +3,7 @@ from senza.aws import resolve_security_groups
 from senza.components.elastic_load_balancer import (ALLOWED_LOADBALANCER_SCHEMES,
                                                     get_load_balancer_name,
                                                     get_ssl_cert)
-from senza.utils import generate_valid_cloud_name;
+from senza.utils import generate_valid_cloud_name
 from senza.definitions import AccountArguments
 
 from ..cli import TemplateArguments

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -75,9 +75,11 @@ def component_elastic_load_balancer_v2(definition,
     health_check_port = configuration.get("HealthCheckPort") or configuration["HTTPPort"]
 
     if configuration.get('LoadBalancerName'):
-        loadbalancer_name = get_load_balancer_name(configuration["LoadBalancerName"], info["StackVersion"])
+        loadbalancer_name = get_load_balancer_name(configuration["LoadBalancerName"], 32)
     elif configuration.get('NameSuffix'):
-        loadbalancer_name = generate_valid_cloud_name(info["StackName"], 32)
+        version = '{}-{}'.format(info["StackVersion"],
+                                 configuration['NameSuffix'])
+        loadbalancer_name = get_load_balancer_name(info["StackName"], version)
         del(configuration['NameSuffix'])
     else:
         loadbalancer_name = get_load_balancer_name(info["StackName"],

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -2,8 +2,8 @@ import click
 from senza.aws import resolve_security_groups
 from senza.components.elastic_load_balancer import (ALLOWED_LOADBALANCER_SCHEMES,
                                                     get_load_balancer_name,
-						    generate_valid_cloud_name,
                                                     get_ssl_cert)
+from senza.utils import generate_valid_cloud_name;
 from senza.definitions import AccountArguments
 
 from ..cli import TemplateArguments

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -73,7 +73,9 @@ def component_elastic_load_balancer_v2(definition,
     health_check_path = configuration.get("HealthCheckPath") or '/health'
     health_check_port = configuration.get("HealthCheckPort") or configuration["HTTPPort"]
 
-    if configuration.get('NameSuffix'):
+    if configuration.get('LoadBalancerName'):
+        loadbalancer_name = get_load_balancer_name(configuration["LoadBalancerName"], info["StackVersion"])
+    elif configuration.get('NameSuffix'):
         version = '{}-{}'.format(info["StackVersion"],
                                  configuration['NameSuffix'])
         loadbalancer_name = get_load_balancer_name(info["StackName"], version)

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -75,7 +75,7 @@ def component_elastic_load_balancer_v2(definition,
     health_check_port = configuration.get("HealthCheckPort") or configuration["HTTPPort"]
 
     if configuration.get('LoadBalancerName'):
-        loadbalancer_name = get_load_balancer_name(configuration["LoadBalancerName"], 32)
+        loadbalancer_name = generate_valid_cloud_name(configuration["LoadBalancerName"], 32)
     elif configuration.get('NameSuffix'):
         version = '{}-{}'.format(info["StackVersion"],
                                  configuration['NameSuffix'])

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -2,6 +2,7 @@ import click
 from senza.aws import resolve_security_groups
 from senza.components.elastic_load_balancer import (ALLOWED_LOADBALANCER_SCHEMES,
                                                     get_load_balancer_name,
+						    generate_valid_cloud_name,
                                                     get_ssl_cert)
 from senza.definitions import AccountArguments
 
@@ -76,9 +77,7 @@ def component_elastic_load_balancer_v2(definition,
     if configuration.get('LoadBalancerName'):
         loadbalancer_name = get_load_balancer_name(configuration["LoadBalancerName"], info["StackVersion"])
     elif configuration.get('NameSuffix'):
-        version = '{}-{}'.format(info["StackVersion"],
-                                 configuration['NameSuffix'])
-        loadbalancer_name = get_load_balancer_name(info["StackName"], version)
+        loadbalancer_name = generate_valid_cloud_name(info["StackName"], 32)
         del(configuration['NameSuffix'])
     else:
         loadbalancer_name = get_load_balancer_name(info["StackName"],

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -49,6 +49,14 @@ def pystache_render(*args, **kwargs):
     return render.render(*args, **kwargs)
 
 
+def generate_valid_cloud_name(name: str, length: int):
+    """
+	Generate a name with that length and remove double - signs
+        remove a starting or trailing -
+    """
+    return re.sub(r'(-(?=-{1,})|^-|-$)', '', name[:length])
+
+
 def get_load_balancer_name(stack_name: str, stack_version: str):
     """
     Returns the name of the load balancer for the stack name and version,
@@ -56,4 +64,4 @@ def get_load_balancer_name(stack_name: str, stack_version: str):
     """
     # Loadbalancer name cannot exceed 32 characters, try to shorten
     l = 32 - len(stack_version) - 1
-    return '{}-{}'.format(stack_name[:l], stack_version)
+    return '{}-{}'.format(generate_valid_cloud_name(stack_name, l), stack_version)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -13,7 +13,7 @@ from senza.components.auto_scaling_group import (component_auto_scaling_group,
                                                  to_iso8601_duration)
 from senza.components.coreos_auto_configuration import component_coreos_auto_configuration
 from senza.components.elastic_load_balancer import (component_elastic_load_balancer,
-                                                    get_load_balancer_name)
+                                                    get_load_balancer_name, generate_valid_cloud_name)
 from senza.components.elastic_load_balancer_v2 import component_elastic_load_balancer_v2
 from senza.components.iam_role import component_iam_role, get_merged_policies
 from senza.components.redis_cluster import component_redis_cluster

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -13,7 +13,7 @@ from senza.components.auto_scaling_group import (component_auto_scaling_group,
                                                  to_iso8601_duration)
 from senza.components.coreos_auto_configuration import component_coreos_auto_configuration
 from senza.components.elastic_load_balancer import (component_elastic_load_balancer,
-                                                    get_load_balancer_name, generate_valid_cloud_name)
+                                                    get_load_balancer_name)
 from senza.components.elastic_load_balancer_v2 import component_elastic_load_balancer_v2
 from senza.components.iam_role import component_iam_role, get_merged_policies
 from senza.components.redis_cluster import component_redis_cluster

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from senza.utils import camel_case_to_underscore, get_load_balancer_name
+from senza.utils import camel_case_to_underscore, get_load_balancer_name, generate_valid_cloud_name
 
 
 def test_camel_case_to_underscore():
@@ -11,3 +11,11 @@ def test_get_load_balancer_name():
     assert get_load_balancer_name(stack_name='really-long-application-name',
                                   stack_version='cd871c54') == 'really-long-application-cd871c54'
     assert get_load_balancer_name(stack_name='app-name', stack_version='1') == 'app-name-1'
+
+
+def test_generate_valid_cloud_name():
+    assert generate_valid_cloud_name(name='invalid-aws--cloud-name', length=32) == 'invalid-aws-cloud-name'
+    assert generate_valid_cloud_name(name='-invalid-aws-cloud-name', length=32) == 'invalid-aws-cloud-name'
+    assert generate_valid_cloud_name(name='invalid-aws-cloud-name-', length=32) == 'invalid-aws-cloud-name'
+    assert generate_valid_cloud_name(name='invalid-aws--cloud-name-', length=32) == 'invalid-aws-cloud-name'
+    assert generate_valid_cloud_name(name='invalid-aws-cloud-name-long-replaced', length=27) == 'invalid-aws-cloud-name-long'


### PR DESCRIPTION
Issue Number: #467

The old ELB Configuration has a Property "LoadBalancerName", the new ALB Configuration not. If we support this property in ALB, user can switch from ELB to ALB and will have the same LoadBalancerName.