### PR TITLE
remove dns.resolver import error handling

### DIFF
--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -8,7 +8,8 @@ from typing import Dict, Iterator
 
 import boto3
 import click
-from clickclick import Action, action, fatal_error, ok, print_table, warning
+import dns.resolver
+from clickclick import Action, action, ok, print_table, warning
 
 from .aws import StackReference, get_stacks, get_tag
 from .manaus import ClientError
@@ -18,12 +19,6 @@ from .manaus.exceptions import ELBNotFound, StackNotFound, StackNotUpdated
 from .manaus.route53 import (RecordType, Route53, Route53HostedZone,
                              convert_cname_records_to_alias)
 from .manaus.utils import extract_client_error_code
-
-try:
-    import dns.resolver
-except ImportError:
-    fatal_error("Failed to import dns.resolver.\n"
-                "Run 'pip3 install -U --force-reinstall dnspython'.")
 
 PERCENT_RESOLUTION = 2
 FULL_PERCENTAGE = PERCENT_RESOLUTION * 100

--- a/tests/test_traffic.py
+++ b/tests/test_traffic.py
@@ -102,22 +102,3 @@ def test_resolve_to_ip_addresses(monkeypatch):
     query.side_effect = None
     query.return_value = [MagicMock(address='1.2.3.4')]
     assert resolve_to_ip_addresses('example.org') == {'1.2.3.4'}
-
-
-def test_dns_import(monkeypatch):
-    realimport = builtins.__import__
-
-    def fake_import(name: str, *args, **kwargs):
-        if name == 'dns':
-            raise ImportError()
-        else:
-            m = realimport(name, *args, **kwargs)
-            return m
-
-    monkeypatch.setattr(builtins, '__import__', fake_import)
-    m_fatal_error = MagicMock()
-    monkeypatch.setattr('clickclick.fatal_error', m_fatal_error)
-    importlib.reload(senza.traffic)
-    m_fatal_error.assert_called_once_with("Failed to import dns.resolver.\n"
-                                          "Run 'pip3 install -U "
-                                          "--force-reinstall dnspython'.")


### PR DESCRIPTION
The import error handling is no longer needed (the use case was the migration from dnspython3 to dnspython).

This fixes the failing unit test.