### PR TITLE
Fix issue with changed set traffic handling

### DIFF
--- a/senza/traffic.py
+++ b/senza/traffic.py
@@ -146,8 +146,11 @@ def set_new_weights(dns_names: list,
                 # Stack weight will not change
                 continue
             try:
-                stack = CloudFormationStack.get_by_stack_name(stack_name,
-                                                              region=region)
+                if stack_name not in updates.keys():
+                    stack = CloudFormationStack.get_by_stack_name(stack_name,
+                                                                  region=region)
+                else:
+                    stack = updates[stack_name]['stack']
             except StackNotFound:
                 # The Route53 record doesn't have an associated stack
                 # fallback to the old logic


### PR DESCRIPTION
The PR which introduced the changed handling of set traffic solving the UPDATE_IN_PROGRESS issue with stacks having multiple ELBs (and therefore multiple DNS names) did treat a `stack` object returned by `CloudFormationStack.get_by_stack_name` as if it would be the same object being returned by subsequent calls with the same stack_name. As this is not the case this leads to only the first update being actually executed.