### PR TITLE
Fix zappr yaml

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -8,4 +8,4 @@ approvals:
       minimum: 2
       from:
         orgs:
-          - zalando-stups
+          - zalando


### PR DESCRIPTION
The only org allowed in zappr.yaml is zalando.