### PR TITLE
Fix TCP mode for the ELB component by using a correct health check

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -130,7 +130,11 @@ def component_elastic_load_balancer(definition,
     if health_check_protocol not in ALLOWED_HEALTH_CHECK_PROTOCOLS:
         raise click.UsageError('Protocol "{}" is not supported for LoadBalancer'.format(health_check_protocol))
 
-    health_check_path = configuration.get("HealthCheckPath") or '/health'
+    if health_check_protocol in ['HTTP', 'HTTPS']:
+      health_check_path = configuration.get("HealthCheckPath") or '/health'
+    else:
+      health_check_path = ''
+
     health_check_port = configuration.get("HealthCheckPort") or configuration["HTTPPort"]
 
     health_check_target = "{0}:{1}{2}".format(health_check_protocol,

--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -131,9 +131,9 @@ def component_elastic_load_balancer(definition,
         raise click.UsageError('Protocol "{}" is not supported for LoadBalancer'.format(health_check_protocol))
 
     if health_check_protocol in ['HTTP', 'HTTPS']:
-      health_check_path = configuration.get("HealthCheckPath") or '/health'
+        health_check_path = configuration.get("HealthCheckPath") or '/health'
     else:
-      health_check_path = ''
+        health_check_path = ''
 
     health_check_port = configuration.get("HealthCheckPort") or configuration["HTTPPort"]
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -99,7 +99,7 @@ def test_component_load_balancer_healthcheck(monkeypatch):
     m_acm.get_certificates.return_value = iter([m_acm_certificate])
     configuration["HealthCheckProtocol"] = "TCP"
     result = component_elastic_load_balancer(definition, configuration, args, info, False, MagicMock())
-    assert "TCP:9999/healthcheck" == result["Resources"]["test_lb"]["Properties"]["HealthCheck"]["Target"]
+    assert "TCP:9999" == result["Resources"]["test_lb"]["Properties"]["HealthCheck"]["Target"]
 
     # Will fail on incorrect protocol
     m_acm.get_certificates.return_value = iter([m_acm_certificate])


### PR DESCRIPTION
HTTP and HTTPS have `HTTP(S):<port><path>` target syntax but TCP does not know about paths: `TCP:<port>`.

See here:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb-health-check.html#cfn-elb-healthcheck-target