### PR TITLE
#478 - 'senza scale' prompt when more than one instance might be scaled.

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1473,9 +1473,10 @@ def respawn_instances(stack_ref, inplace, force, region):
 @cli.command()
 @click.argument('stack_ref', nargs=-1)
 @click.argument('desired_capacity', type=click.IntRange(0, 100, clamp=True))
+@click.option('--force', ' /-F', default=False, help='Force scaling multiple stacks if needed')
 @region_option
 @stacktrace_visible_option
-def scale(stack_ref, region, desired_capacity):
+def scale(stack_ref, region, desired_capacity, force):
     '''Scale Auto Scaling Group to desired capacity'''
 
     stack_refs = get_stack_refs(stack_ref)
@@ -1483,6 +1484,11 @@ def scale(stack_ref, region, desired_capacity):
     check_credentials(region)
 
     asg = BotoClientProxy('autoscaling', region)
+
+    stack_count = len(list(get_stacks(stack_refs, region)))
+    if not force and stack_count > 1:
+        confirm_str = 'Number of stacks to be scaled - %s. Do you want to continue?' % stack_count
+        click.confirm(confirm_str, abort=True)
 
     for asg_name in get_auto_scaling_groups(stack_refs, region):
         group = get_auto_scaling_group(asg, asg_name)

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1487,7 +1487,7 @@ def scale(stack_ref, region, desired_capacity, force):
 
     stack_count = len(list(get_stacks(stack_refs, region)))
     if not force and stack_count > 1:
-        confirm_str = 'Number of stacks to be scaled - %s. Do you want to continue?' % stack_count
+        confirm_str = 'Number of stacks to be scaled - {}. Do you want to continue?'.format(stack_count)
         click.confirm(confirm_str, abort=True)
 
     for asg_name in get_auto_scaling_groups(stack_refs, region):

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1473,7 +1473,9 @@ def respawn_instances(stack_ref, inplace, force, region):
 @cli.command()
 @click.argument('stack_ref', nargs=-1)
 @click.argument('desired_capacity', type=click.IntRange(0, 100, clamp=True))
-@click.option('--force', ' /-F', default=False, help='Force scaling multiple stacks if needed')
+@click.option('-f', '--force',
+              is_flag=True,
+              help='Force scaling multiple stacks if needed')
 @region_option
 @stacktrace_visible_option
 def scale(stack_ref, region, desired_capacity, force):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1587,6 +1587,44 @@ def test_scale(monkeypatch):
                            catch_exceptions=False)
     assert 'Scaling myasg from 1 to 2 instances' in result.output
 
+def test_scale_with_confirm(monkeypatch):
+    boto3 = MagicMock()
+    boto3.list_stacks.return_value = {'StackSummaries': [
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-14'},
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-15'},
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-16'},
+    ]}
+    boto3.describe_stack_resources.return_value = {'StackResources':
+                                                       [{'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+                                                         'PhysicalResourceId': 'myasg'}]}
+    group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 1, 'MinSize': 3, 'MaxSize': 1}
+    boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+    monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+    runner = CliRunner()
+    result = runner.invoke(cli, ['scale', 'myapp', '2', '--region=aa-fakeregion-1'],
+                           catch_exceptions=False)
+    assert 'Number of stacks to be scaled - 3. Do you want to continue?' in result.output
+
+
+def test_scale_with_force_confirm(monkeypatch):
+    boto3 = MagicMock()
+    boto3.list_stacks.return_value = {'StackSummaries': [
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-14'},
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-15'},
+        {'StackName': 'myapp-1', 'CreationTime': '2016-06-16'},
+    ]}
+    boto3.describe_stack_resources.return_value = {'StackResources':
+                                                       [{'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+                                                         'PhysicalResourceId': 'myasg'}]}
+    group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 1, 'MinSize': 3, 'MaxSize': 1}
+    boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+    monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+    runner = CliRunner()
+    result = runner.invoke(cli, ['scale', 'myapp', '2', '--region=aa-fakeregion-1', '--force'],
+                           catch_exceptions=False)
+    assert 'Scaling myasg from 1 to 2 instances' in result.output
+
+
 
 def test_wait(monkeypatch):
     cf = MagicMock()


### PR DESCRIPTION
#478 fixed. 

* User should confirm operation when more than one stack found to scale. 
* `--force` flag used to turn off confirmation and scale all found instances.