### PR TITLE
#493: Support ClusterName for RedisNode component

### DIFF
--- a/senza/components/redis_node.py
+++ b/senza/components/redis_node.py
@@ -4,7 +4,7 @@ from senza.utils import ensure_keys
 
 
 def component_redis_node(definition, configuration, args, info, force, account_info):
-    name = configuration["Name"]
+    name = configuration.get("ClusterName", configuration["Name"])
     definition = ensure_keys(definition, "Resources")
 
     definition["Resources"]["RedisCacheCluster"] = {

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -358,6 +358,41 @@ def test_component_redis_node(monkeypatch):
     assert 'SubnetIds' in result['Resources']['RedisSubnetGroup']['Properties']
 
 
+def test_component_redis_node_cluster_name(monkeypatch):
+    mock_string = "foo"
+    cluster_name = "foo-redis-cluster"
+
+    configuration = {
+        "Name": mock_string,
+        "SecurityGroups": "",
+        "ClusterName": cluster_name,
+    }
+    info = {'StackName': 'foobar' * 5, 'StackVersion': '0.1'}
+    definition = {"Resources": {}}
+
+    args = MagicMock()
+    args.region = "foo"
+
+    mock_string_result = MagicMock()
+    mock_string_result.return_value = mock_string
+    monkeypatch.setattr('senza.components.redis_node.resolve_security_groups', mock_string_result)
+
+    result = component_redis_node(definition, configuration, args, info, False, MagicMock())
+
+    assert 'RedisCacheCluster' in result['Resources']
+    assert mock_string == result['Resources']['RedisCacheCluster']['Properties']['VpcSecurityGroupIds']
+    assert cluster_name == result['Resources']['RedisCacheCluster']['Properties']['ClusterName']
+    assert 1 == result['Resources']['RedisCacheCluster']['Properties']['NumCacheNodes']
+    assert 'Engine' in result['Resources']['RedisCacheCluster']['Properties']
+    assert 'EngineVersion' in result['Resources']['RedisCacheCluster']['Properties']
+    assert 'CacheNodeType' in result['Resources']['RedisCacheCluster']['Properties']
+    assert 'CacheSubnetGroupName' in result['Resources']['RedisCacheCluster']['Properties']
+    assert 'CacheParameterGroupName' in result['Resources']['RedisCacheCluster']['Properties']
+
+    assert 'RedisSubnetGroup' in result['Resources']
+    assert 'SubnetIds' in result['Resources']['RedisSubnetGroup']['Properties']
+
+
 def test_component_redis_cluster(monkeypatch):
     mock_string = "foo"
 


### PR DESCRIPTION
This PR adds support for `ClusterName` property which can be used inside `RedisNode` component definition in order to specify the name of the Redis cluster. If `ClusterName` is not provided the name of the definition will be used instead.