### PR TITLE
fix senza not to put NAT subnets into server subnets

### DIFF
--- a/senza/components/subnet_auto_configuration.py
+++ b/senza/components/subnet_auto_configuration.py
@@ -33,6 +33,8 @@ def component_subnet_auto_configuration(definition, configuration, args, info, f
             elif 'internal' in name:
                 lb_internal_subnets.append(subnet.id)
                 server_subnets.append(subnet.id)
+            elif 'nat' in name:
+                pass # ignore creating listeners in NAT gateway subnets
             else:
                 server_subnets.append(subnet.id)
 


### PR DESCRIPTION
NAT gateways created by https://github.com/szuecs/kube-static-egress-controller/ will also get a new subnet, because servers could be placed in dmz or private subnets and both has to be routed for given static egress targets.

Senza will normally find these NAT subnets and place ELB interfaces into them, which create failures at runtime.