### PR TITLE
support multiple SSL certificates for ELBv2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -463,6 +463,41 @@ Additionally, you can specify any of the `valid AWS CloudFormation ELB propertie
 
 .. _valid AWS CloudFormation ELB properties: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html
 
+WeightedDnsElasticLoadBalancerV2
+==================================
+
+Similar to the WeightedDnsElasticLoadBalancer component **WeightedDnsElasticLoadBalancerV2** creates one HTTPs ELBv2 resource with Route 53 weighted domains.
+ELBv2 listeners support SNI, hence you can specify multiple SSL certificates.
+
+.. code-block:: yaml
+
+    SenzaComponents:
+      - AppLoadBalancer:
+          Type: Senza::WeightedDnsElasticLoadBalancerV2
+          HTTPPort: 8080
+          SecurityGroups:
+            - app-myapp-lb
+
+The WeightedDnsElasticLoadBalancerV2 component supports the following configuration properties:
+
+``HTTPPort``
+    The HTTP port used by the EC2 instances.
+``HealthCheckPath``
+    The HTTP path to use for health checks, e.g. "/health". Must return 200.
+``HealthCheckPort``
+    Optional. Port used for the health check. Defaults to ``HTTPPort``.
+``SecurityGroups``
+    List of security groups to use for the ELBv2. The security groups must allow SSL traffic.
+``MainDomain``
+    Main domain to use, e.g. "myapp.example.org".
+``VersionDomain``
+    Version domain to use, e.g. "myapp-1.example.org". You can use the usual templating feature to integrate the stack version, e.g. ``myapp-{{SenzaInfo.StackVersion}}.example.org``.
+``Scheme``
+    The load balancer scheme. Either ``internal`` or ``internet-facing``. Defaults to ``internal``.
+``SSLCertificateId``
+    A comma-separated list of names or ARN ID of the uploaded SSL/TLS server certificates to use, e.g. ``myapp-example-org-letsencrypt`` or ``arn:aws:acm:eu-central-1:123123123:certificate/abcdefgh-ijkl-mnop-qrst-uvwxyz012345``.
+    You can check available IAM server certificates with :code:`aws iam list-server-certificates`. For ACM certificates, use :code:`aws acm list-certificates`.
+
 Cross-Stack References
 ======================
 

--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -16,9 +16,7 @@ ALLOWED_HEALTH_CHECK_PROTOCOLS = frozenset(["HTTP", "HTTPS", "TCP", "UDP", "SSL"
 ALLOWED_LOADBALANCER_SCHEMES = frozenset(["internet-facing", "internal"])
 
 
-def get_ssl_cert(subdomain, main_zone, configuration, account_info: AccountArguments):
-    ssl_cert = configuration.get('SSLCertificateId')
-
+def get_ssl_cert(subdomain, main_zone, ssl_cert, account_info: AccountArguments):
     if ACMCertificate.arn_is_acm_certificate(ssl_cert):
         # check if certificate really exists
         try:
@@ -83,7 +81,7 @@ def resolve_ssl_certificates(listeners, subdomain, main_zone, account_info):
     new_listeners = []
     for listener in listeners:
         if listener.get('Protocol') in ('HTTPS', 'SSL'):
-            ssl_cert = get_ssl_cert(subdomain, main_zone, listener, account_info)
+            ssl_cert = get_ssl_cert(subdomain, main_zone, listener.get('SSLCertificateId'), account_info)
             listener['SSLCertificateId'] = ssl_cert
         new_listeners.append(listener)
     return new_listeners

--- a/senza/components/elastic_load_balancer_v2.py
+++ b/senza/components/elastic_load_balancer_v2.py
@@ -28,7 +28,7 @@ def get_listeners(lb_name, target_group_name, subdomain, main_zone, configuratio
         'Type': 'AWS::ElasticLoadBalancingV2::Listener',
         'Properties': {
             "Certificates":
-                list({'CertificateArn': get_ssl_cert(subdomain, main_zone, cert, account_info)} for cert in ssl_certs),
+                [{'CertificateArn': get_ssl_cert(subdomain, main_zone, cert, account_info)} for cert in ssl_certs],
             "Protocol": "HTTPS",
             "DefaultActions": [{'Type': 'forward', 'TargetGroupArn': {'Ref': target_group_name}}],
             'LoadBalancerArn': {'Ref': lb_name},

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -930,7 +930,7 @@ def test_get_load_balancer_name():
                            '1') == 'toolong12345678901234567890123-1'
 
 
-def test_weighted_dns_load_balancer_v2_no_certificate(monkeypatch, boto_client, boto_resource):  # noqa: F811
+def test_weighted_dns_load_balancer_v2(monkeypatch, boto_client, boto_resource):  # noqa: F811
     senza.traffic.DNS_ZONE_CACHE = {}
 
     configuration = {
@@ -983,33 +983,9 @@ def test_weighted_dns_load_balancer_v2_no_certificate(monkeypatch, boto_client, 
     ]
     assert result['Resources']['MyLB']['Properties']['SecurityGroups'] == ['sg-foo']
 
+    # test again with comma-separated certificates
+    configuration['SSLCertificateId'] = 'my-cert,my-other-cert'
 
-def test_weighted_dns_load_balancer_v2_two_certificates(monkeypatch, boto_client, boto_resource):  # noqa: F811
-    senza.traffic.DNS_ZONE_CACHE = {}
-
-    configuration = {
-        "Name": "MyLB",
-        "SecurityGroups": "",
-        "HTTPPort": "9999",
-        'MainDomain': 'great.api.zo.ne',
-        'SSLCertificateId': 'my-cert,my-other-cert',
-        'VersionDomain': 'version.api.zo.ne',
-        # test overwritting specific properties in one of the resources
-        'TargetGroupAttributes': [{'Key': 'deregistration_delay.timeout_seconds', 'Value': '123'}],
-        # test that Security Groups are resolved
-        'SecurityGroups': ['foo-security-group']
-    }
-    info = {'StackName': 'foobar', 'StackVersion': '0.1'}
-    definition = {"Resources": {}}
-
-    args = MagicMock()
-    args.region = "foo"
-
-    mock_string_result = MagicMock()
-    mock_string_result.return_value = ['sg-foo']
-    monkeypatch.setattr('senza.components.elastic_load_balancer_v2.resolve_security_groups', mock_string_result)
-
-    get_ssl_cert = MagicMock()
     get_ssl_cert.side_effect = ['arn:aws:42', 'arn:aws:13']
     monkeypatch.setattr('senza.components.elastic_load_balancer_v2.get_ssl_cert', get_ssl_cert)
 
@@ -1020,24 +996,30 @@ def test_weighted_dns_load_balancer_v2_two_certificates(monkeypatch, boto_client
                                                              False,
                                                              AccountArguments('dummyregion'))
 
-    assert 'MyLB' in result["Resources"]
-    assert 'MyLBListener' in result["Resources"]
-    assert 'MyLBTargetGroup' in result["Resources"]
-
-    target_group = result['Resources']['MyLBTargetGroup']
     lb_listener = result['Resources']['MyLBListener']
-
-    assert target_group['Properties']['HealthCheckPort'] == '9999'
     assert lb_listener['Properties']['Certificates'] == [
         {'CertificateArn': 'arn:aws:42'},
         {'CertificateArn': 'arn:aws:13'}
     ]
-    # test that our custom drain setting works
-    assert target_group['Properties']['TargetGroupAttributes'] == [
-        {'Key': 'deregistration_delay.timeout_seconds',
-         'Value': '123'}
+
+    # test again with certificates as list
+    configuration['SSLCertificateId'] = ['my-cert','my-other-cert']
+
+    get_ssl_cert.side_effect = ['arn:aws:42', 'arn:aws:13']
+    monkeypatch.setattr('senza.components.elastic_load_balancer_v2.get_ssl_cert', get_ssl_cert)
+
+    result = component_weighted_dns_elastic_load_balancer_v2(definition,
+                                                             configuration,
+                                                             args,
+                                                             info,
+                                                             False,
+                                                             AccountArguments('dummyregion'))
+
+    lb_listener = result['Resources']['MyLBListener']
+    assert lb_listener['Properties']['Certificates'] == [
+        {'CertificateArn': 'arn:aws:42'},
+        {'CertificateArn': 'arn:aws:13'}
     ]
-    assert result['Resources']['MyLB']['Properties']['SecurityGroups'] == ['sg-foo']
 
 
 def test_max_description_length():


### PR DESCRIPTION
- add support for multiple SSL certificates for ELBv2
- support both comma-separated string and list

Since ELBv2 supports SNI this commit will enable to put more than only one certificate in the Senza definition.