### PR TITLE
Disable InstanceMonitoring for LaunchConfiguration if needed

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -12,7 +12,7 @@ SENZA_PROPERTIES = frozenset(['SecurityGroups', 'Tags'])
 
 # additional CF properties which can be overwritten
 ADDITIONAL_PROPERTIES = {
-    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile', 
+    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile',
                                                         'SpotPrice', 'InstanceMonitoring']),
     'AWS::AutoScaling::AutoScalingGroup': frozenset(['MetricsCollection', 'TargetGroupARNs',
                                                      'TerminationPolicies', 'PlacementGroup'])

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -12,7 +12,8 @@ SENZA_PROPERTIES = frozenset(['SecurityGroups', 'Tags'])
 
 # additional CF properties which can be overwritten
 ADDITIONAL_PROPERTIES = {
-    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile', 'SpotPrice', 'InstanceMonitoring']),
+    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile', 
+                                                        'SpotPrice', 'InstanceMonitoring']),
     'AWS::AutoScaling::AutoScalingGroup': frozenset(['MetricsCollection', 'TargetGroupARNs',
                                                      'TerminationPolicies', 'PlacementGroup'])
 }

--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -12,7 +12,7 @@ SENZA_PROPERTIES = frozenset(['SecurityGroups', 'Tags'])
 
 # additional CF properties which can be overwritten
 ADDITIONAL_PROPERTIES = {
-    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile', 'SpotPrice']),
+    'AWS::AutoScaling::LaunchConfiguration': frozenset(['BlockDeviceMappings', 'IamInstanceProfile', 'SpotPrice', 'InstanceMonitoring']),
     'AWS::AutoScaling::AutoScalingGroup': frozenset(['MetricsCollection', 'TargetGroupARNs',
                                                      'TerminationPolicies', 'PlacementGroup'])
 }


### PR DESCRIPTION
There should be a way to disable InstanceMonitoring if its not needed for LaunchConfiguration