### PR TITLE
Use Pier One v2 API to check if image exists

### DIFF
--- a/senza/docker.py
+++ b/senza/docker.py
@@ -17,12 +17,12 @@ def docker_image_exists(docker_image: str) -> bool:
 
     for scheme in 'https', 'http':
         try:
-            url = '{scheme}://{registry}/v1/repositories/{repo}/tags'.format(scheme=scheme,
+            url = '{scheme}://{registry}/v2/{repo}/tags/list'.format(scheme=scheme,
                                                                              registry=registry,
                                                                              repo=repo)
             response = requests.get(url, timeout=5)
             result = response.json()
-            return tag in result
+            return tag in result.get('tags', [])
         except requests.RequestException:
             pass
     return False

--- a/senza/docker.py
+++ b/senza/docker.py
@@ -18,8 +18,8 @@ def docker_image_exists(docker_image: str) -> bool:
     for scheme in 'https', 'http':
         try:
             url = '{scheme}://{registry}/v2/{repo}/tags/list'.format(scheme=scheme,
-                                                                             registry=registry,
-                                                                             repo=repo)
+                                                                     registry=registry,
+                                                                     repo=repo)
             response = requests.get(url, timeout=5)
             result = response.json()
             return tag in result.get('tags', [])

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -10,7 +10,7 @@ def test_docker_image_exists(monkeypatch):
     monkeypatch.setattr('requests.get', get)
 
     get.return_value = MagicMock(name='response')
-    get.return_value.json = lambda: {'1.0': 'foo'}
+    get.return_value.json = lambda: {'tags': ['1.0']}
     assert docker_image_exists('my-registry/foo/bar:1.0') is True
 
     get.side_effect = requests.HTTPError()


### PR DESCRIPTION
We want to drop v1 support from Pier One, senza is one of the remaining users of it.