### PR TITLE
Extend spotinst elastigroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install --upgrade tox tox-travis coveralls setuptools
+  - pip install --upgrade "six>=0.11" tox tox-travis coveralls setuptools
 script:
   - tox
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install --upgrade "six>=0.11" tox tox-travis coveralls setuptools
+  - pip install -U setuptools && pip install tox tox-travis coveralls
 script:
   - tox
 after_success:

--- a/examples/elastigroup.yaml
+++ b/examples/elastigroup.yaml
@@ -1,8 +1,7 @@
 SenzaInfo:
   StackName: hello-world
-  StackVersion: one
-  VpcID: vpc-11111111
-  SpotinstAccessToken: <spotinst-token>
+  StackVersion: latest
+  SpotinstAccessToken: <5da...dc7> # Token created using the SpotInst console for the target account
 
 SenzaComponents:
   - Configuration:
@@ -11,46 +10,29 @@ SenzaComponents:
   - AppServerElastigroup:
       Type: Spotinst::Elastigroup
       Elastigroup:
-        name: Spotinst-CloudFormation
-        strategy:
-          risk: 100
-          availabilityVsCost: balanced
-        capacity:
-          target: 1
-          minimum: 1
-          maximum: 1
-        scaling: {}
         compute:
           instanceTypes:
             ondemand: m3.large
             spot:
-            - m3.large
-            - m4.large
-            - c3.large
-            - c4.large
-          availabilityZones:
-          - name: us-west-2a
-            subnetId: subnet-11111111
-          - name: us-west-2b
-            subnetId: subnet-11111112
+              - m3.large
+              - m4.large
+              - c3.large
+              - c4.large
           launchSpecification:
-            monitoring: false
-            Image: LatestTaupageImage
-            keyPair: default
-            SecurityGroups: default
+            SecurityGroups: default # for this to work make sure the default security group allows ingress on TCP/8000
             ElasticLoadBalancer: AppLoadBalancer
-          product: Linux/UNIX
-        scheduling: {}
-        thirdPartiesIntegration: {}
+      TaupageConfig:
+        runtime: Docker
+        source: "crccheck/hello-world:latest"
+        health_check_path: /
+        ports:
+          8000: 8000
 
   - AppLoadBalancer:
-            Type: Senza::ElasticLoadBalancer
-            Name: Spotinst-CloudFormation
-            HTTPPort: 8080
-            HealthCheckPath: /hello-world/
-            SecurityGroups: [default]
-            Scheme: internet-facing
-            Listeners:
-                - Protocol: HTTP
-                  InstancePort: 80
-                  LoadBalancerPort: 80
+      Type: Senza::WeightedDnsElasticLoadBalancer
+      HTTPPort: 8000
+      HealthCheckPath: /
+      SecurityGroups:
+        - default # for this to work make sure the default security group allows ingress on TCP/443
+      Scheme: internal
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+requests
 arrow
 clickclick>=1.0
 pystache

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -221,7 +221,7 @@ def evaluate(definition, args, account_info, force: bool):
     # extract Senza* meta information
     info = definition.pop("SenzaInfo")
     info["StackVersion"] = args.version
-    # replace Arguments and AccountInfo Variabales in info section
+    # replace Arguments and AccountInfo Variables in info section
     info = yaml.safe_load(evaluate_template(yaml.dump(info), {}, {}, args, account_info))
 
     # add info as mappings

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ def setup_package():
         install_requires=install_reqs,
         setup_requires=['flake8'],
         cmdclass=cmdclass,
-        tests_require=['pytest-cov', 'pytest', 'mock'],
+        tests_require=['pytest-cov', 'pytest', 'mock', 'responses'],
         command_options=command_options,
         entry_points={'console_scripts': CONSOLE_SCRIPTS,
                       'senza.templates': ['bgapp = senza.templates.bgapp',

--- a/spotinst/__init__.py
+++ b/spotinst/__init__.py
@@ -1,5 +1,18 @@
 """
 Deploy Spotinst Elastigroups using AWS CloudFormation templates
 """
+from senza.exceptions import SenzaException
 
 __version__ = '0.1'
+
+
+class MissingSpotinstAccount(SenzaException):
+    """
+    Exception raised when failed to map the target cloud account to a spotinst account
+    """
+
+    def __init__(self, cloud_account_id: str):
+        self.cloud_account_id = cloud_account_id
+
+    def __str__(self):
+        return "{cloud_account_id} cloud account was not found in your Spotinst organization ".format_map(vars(self))

--- a/spotinst/components/elastigroup.py
+++ b/spotinst/components/elastigroup.py
@@ -131,7 +131,7 @@ def extract_subnets(definition, elastigroup_config, account_info):
     """
     subnet_ids = elastigroup_config["compute"].get("subnetIds", [])
     target_region = elastigroup_config.get("region", account_info.Region)
-    if len(subnet_ids) < 1:
+    if not subnet_ids:
         subnet_ids = [subnetId for subnetId in
                       definition["Mappings"]["ServerSubnets"].get(target_region, {}).get("Subnets", [])]
     elastigroup_config["region"] = target_region

--- a/spotinst/components/elastigroup.py
+++ b/spotinst/components/elastigroup.py
@@ -1,3 +1,7 @@
+"""
+Functions to create Spotinst Elastigroups
+"""
+
 import base64
 import re
 import click

--- a/spotinst/components/elastigroup.py
+++ b/spotinst/components/elastigroup.py
@@ -1,7 +1,29 @@
+import base64
+
+import click
+import pierone
+import requests
+
 from senza.aws import resolve_security_groups
+from senza.components.taupage_auto_scaling_group import check_application_id, check_application_version, \
+    check_docker_image_exists, generate_user_data
 from senza.utils import ensure_keys
 
 SPOTINST_LAMBDA_FORMATION_ARN = 'arn:aws:lambda:{}:178579023202:function:spotinst-cloudformation'
+SPOTINST_API_URL = 'https://api.spotinst.io'
+ELASTIGROUP_DEFAULT_STRATEGY = {"risk": 100, "availabilityVsCost": "balanced"}
+ELASTIGROUP_DEFAULT_CAPACITY = {"target": 1, "minimum": 1, "maximum": 1}
+ELASTIGROUP_DEFAULT_PRODUCT = "Linux/UNIX"
+
+
+def extract_subnets(definition, elastigroup_config, account_info):
+    subnetIds = elastigroup_config["compute"].get("subnetIds", [])
+    targetRegion = elastigroup_config.get("region", account_info.Region)
+    if len(subnetIds) < 1:
+        subnetIds = [subnetId for subnetId in
+                     definition["Mappings"]["ServerSubnets"].get(targetRegion, {}).get("Subnets", [])]
+    elastigroup_config["region"] = targetRegion
+    elastigroup_config["compute"]["subnetIds"] = subnetIds
 
 
 def component_elastigroup(definition, configuration, args, info, force, account_info):
@@ -17,21 +39,113 @@ def component_elastigroup(definition, configuration, args, info, force, account_
 
     # launch configuration
     elastigroup_config = configuration["Elastigroup"]
+    ensure_keys(elastigroup_config, "scaling")
+    ensure_keys(elastigroup_config, "scheduling")
+    ensure_keys(elastigroup_config, "thirdPartiesIntegration")
+
+    fill_standard_tags(definition, elastigroup_config)
+    ensure_default_strategy(elastigroup_config)
+    ensure_default_capacity(elastigroup_config)
+    ensure_default_product(elastigroup_config)
+    ensure_instance_monitoring(elastigroup_config)
+
+    extract_subnets(definition, elastigroup_config, account_info)
+    extract_user_data(configuration, elastigroup_config, info, force, account_info)
     extract_load_balancer_name(elastigroup_config)
     extract_image_id(elastigroup_config)
     extract_security_group_ids(elastigroup_config, args)
 
     # cfn definition
+    access_token = _extract_spotinst_access_token(definition)
     definition["Resources"][config_name] = {
         "Type": "Custom::elastigroup",
         "Properties": {
             "ServiceToken": create_service_token(args.region),
-            "accessToken": _extract_spotinst_access_token(definition),
+            "accessToken": access_token,
+            "accountId": extract_spotinst_account_id(access_token, definition),
             "group": elastigroup_config
         }
     }
 
     return definition
+
+
+def ensure_instance_monitoring(elastigroup_config):
+    if "monitoring" in elastigroup_config["compute"]["launchSpecification"]:
+        return
+    elastigroup_config["compute"]["launchSpecification"]["monitoring"] = True
+
+
+def ensure_default_strategy(elastigroup_config):
+    if "strategy" in elastigroup_config:
+        return
+    elastigroup_config["strategy"] = ELASTIGROUP_DEFAULT_STRATEGY
+
+
+def ensure_default_capacity(elastigroup_config):
+    if "capacity" in elastigroup_config:
+        return
+    elastigroup_config["capacity"] = ELASTIGROUP_DEFAULT_CAPACITY
+
+
+def ensure_default_product(elastigroup_config):
+    if "product" in elastigroup_config["compute"]:
+        return
+    elastigroup_config["compute"]["product"] = ELASTIGROUP_DEFAULT_PRODUCT
+
+
+def fill_standard_tags(definition, elastigroup_config):
+    if "tags" in elastigroup_config["compute"]["launchSpecification"]:
+        return
+
+    name = definition["Mappings"]["Senza"]["Info"]["StackName"]
+    version = definition["Mappings"]["Senza"]["Info"]["StackVersion"]
+    full_name = "{}-{}".format(name, version)
+    elastigroup_config["compute"]["launchSpecification"]["tags"] = [
+        {"tagKey": "Name", "tagValue": full_name},
+        {"tagKey": "StackName", "tagValue": name},
+        {"tagKey": "StackVersion", "tagValue": version}
+    ]
+    if elastigroup_config.get("name", "") == "":
+        elastigroup_config["name"] = full_name
+
+
+def extract_user_data(configuration, elastigroup_config, info: dict, force, account_info):
+    """
+    This function converts a classic TaupageConfig into a base64 encoded value for the
+    compute.launchSpecification.userData
+    See https://api.spotinst.com/elastigroup/amazon-web-services/create/#compute.launchSpecification.userData
+    """
+    taupage_config = configuration.get("TaupageConfig", {})
+    if taupage_config:
+        if 'notify_cfn' not in taupage_config:
+            taupage_config['notify_cfn'] = {'stack': '{}-{}'.format(info["StackName"], info["StackVersion"]),
+                                            'resource': configuration['Name']}
+
+        if 'application_id' not in taupage_config:
+            taupage_config['application_id'] = info['StackName']
+
+        if 'application_version' not in taupage_config:
+            taupage_config['application_version'] = info['StackVersion']
+
+        check_application_id(taupage_config['application_id'])
+        check_application_version(taupage_config['application_version'])
+
+        runtime = taupage_config.get('runtime')
+        if runtime != 'Docker':
+            raise click.UsageError('Taupage only supports the "Docker" runtime currently')
+
+        source = taupage_config.get('source')
+        if not source:
+            raise click.UsageError('The "source" property of TaupageConfig must be specified')
+
+        docker_image = pierone.api.DockerImage.parse(source)
+
+        if not force and docker_image.registry:
+            check_docker_image_exists(docker_image)
+
+        user_data = base64.urlsafe_b64encode(generate_user_data(taupage_config, account_info.Region).encode('utf-8'))
+        elastigroup_config["compute"]["launchSpecification"]["userData"] = user_data.decode('utf-8')
 
 
 def extract_load_balancer_name(elastigroup_config: dict):
@@ -74,10 +188,7 @@ def extract_image_id(elastigroup_config: dict):
     launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
 
     if "imageId" not in launch_spec_config.keys():
-        if "Image" in launch_spec_config.keys():
-            image_ref = launch_spec_config.pop("Image")
-            image_id = {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, image_ref]}
-            launch_spec_config["imageId"] = image_id
+        launch_spec_config["imageId"] = {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "LatestTaupageImage"]}
 
 
 def extract_security_group_ids(elastigroup_config: dict, args):
@@ -116,3 +227,27 @@ def _extract_spotinst_access_token(definition: dict):
     extract the provided access token
     """
     return definition["Mappings"]["Senza"]["Info"]["SpotinstAccessToken"]
+
+
+def extract_spotinst_account_id(access_token: str, definition: dict):
+    """
+    if present, return the template defined Spotinst target account id or use the Spotinst API to
+    list the accounts and return the first account found
+    """
+    template_account_id = definition["Mappings"]["Senza"]["Info"].get("SpotinstAccountId", "")
+    if not template_account_id:
+        template_account_id = resolve_account_id(access_token)
+    return template_account_id
+
+
+def resolve_account_id(access_token):
+    headers = {
+        "Authorization": "Bearer {}".format(access_token),
+        "Content-Type": "application/json"
+    }
+    response = requests.get('{}/setup/account/'.format(SPOTINST_API_URL), headers=headers, timeout=5)
+    response.raise_for_status()
+    data = response.json()
+    accounts = data.get("response", {}).get("items", [])
+    if len(accounts) > 0:
+        return accounts[0].get("accountId")

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -1,0 +1,61 @@
+from mock import MagicMock
+
+from senza.definitions import AccountArguments
+from spotinst.components.elastigroup import component_elastigroup, ELASTIGROUP_DEFAULT_PRODUCT, \
+    ELASTIGROUP_DEFAULT_STRATEGY, ELASTIGROUP_DEFAULT_CAPACITY
+
+
+def test_component_elastigroup_defaults(monkeypatch):
+    configuration = {
+        "Name": "eg1",
+        "Elastigroup": {
+            "compute": {
+                "instanceTypes": {
+                    "ondemand": "big",
+                    "spot": ["smaller", "small"]
+                },
+                "launchSpecification": {
+                    "SecurityGroups": "sg1",
+                    "ElasticLoadBalancer": "lb1"
+                }
+            }
+        }
+    }
+    args = MagicMock()
+    args.region = "reg1"
+    info = {'StackName': 'foobar', 'StackVersion': '0.1', 'SpotinstAccessToken': 'token1'}
+    subnets = ["sn1", "sn2", "sn3"]
+    server_subnets = {"reg1": {"Subnets": subnets}}
+    senza = {"Info": info}
+    mappings = {"Senza": senza, "ServerSubnets": server_subnets}
+    definition = {"Resources": {}, "Mappings": mappings}
+    mock_sg = MagicMock()
+    mock_sg.return_value = "sg1"
+    monkeypatch.setattr('senza.aws.resolve_security_group', mock_sg)
+
+    resolve_account_id = MagicMock()
+    resolve_account_id.return_value = 'act-12345abcdef'
+    monkeypatch.setattr('spotinst.components.elastigroup.resolve_account_id', resolve_account_id)
+
+    result = component_elastigroup(definition, configuration, args, info, False, AccountArguments('reg1'))
+
+    properties = result["Resources"]["eg1Config"]["Properties"]
+    assert properties["accountId"] == 'act-12345abcdef'
+    assert properties["group"]["capacity"] == ELASTIGROUP_DEFAULT_CAPACITY
+    launch_specification = properties["group"]["compute"]["launchSpecification"]
+    assert launch_specification["monitoring"]
+    assert launch_specification["securityGroupIds"] == ["sg1"]
+    tags = launch_specification["tags"]
+    assert {'tagKey': 'Name', 'tagValue': 'foobar-0.1'} in tags
+    assert {'tagKey': 'StackName', 'tagValue': 'foobar'} in tags
+    assert {'tagKey': 'StackVersion', 'tagValue': '0.1'} in tags
+    assert properties["group"]["compute"]["product"] == ELASTIGROUP_DEFAULT_PRODUCT
+    assert properties["group"]["compute"]["subnetIds"] == subnets
+    assert properties["group"]["region"] == "reg1"
+    assert properties["group"]["strategy"] == ELASTIGROUP_DEFAULT_STRATEGY
+
+    assert "scaling" in properties["group"]
+    assert "scheduling" in properties["group"]
+    assert "thirdPartiesIntegration" in properties["group"]
+
+


### PR DESCRIPTION
This change tries to simplify the definition of Elastgroups by assuming some defaults like the native Auto Scaling Group counterpart.

It also adds support for the automatic subnet mapping from `Senza::StupsAutoConfiguration`

It assumes, for now, that the cloud accounts provisioned in Spotinst will be named "aws:<aws-account-id>". This is used for Spotinst cloud account resolution and it's needed to use a specific account instead of the default one.

/cc @danieldop @jmcs 