### PR TITLE
added missing functionality to elastigroup

### DIFF
--- a/examples/elastigroup.yaml
+++ b/examples/elastigroup.yaml
@@ -9,18 +9,14 @@ SenzaComponents:
 
   - AppServerElastigroup:
       Type: Spotinst::Elastigroup
-      Elastigroup:
-        compute:
-          instanceTypes:
-            ondemand: m3.large
-            spot:
-              - m3.large
-              - m4.large
-              - c3.large
-              - c4.large
-          launchSpecification:
-            SecurityGroups: default # for this to work make sure the default security group allows ingress on TCP/8000
-            ElasticLoadBalancer: AppLoadBalancer
+      InstanceType: m3.large
+      SpotAlternatives:
+          - m3.large
+          - m4.large
+          - c3.large
+          - c4.large
+      SecurityGroups: default # for this to work make sure the default security group allows ingress on TCP/8000
+      ElasticLoadBalancerV2: AppLoadBalancer
       TaupageConfig:
         runtime: Docker
         source: "crccheck/hello-world:latest"
@@ -29,7 +25,7 @@ SenzaComponents:
           8000: 8000
 
   - AppLoadBalancer:
-      Type: Senza::WeightedDnsElasticLoadBalancer
+      Type: Senza::WeightedDnsElasticLoadBalancerV2
       HTTPPort: 8000
       HealthCheckPath: /
       SecurityGroups:

--- a/spotinst/components/elastigroup.py
+++ b/spotinst/components/elastigroup.py
@@ -4,11 +4,15 @@ Functions to create Spotinst Elastigroups
 
 import base64
 import re
+import sys
+
 import click
 import pierone
 import requests
+import senza
 
 from senza.aws import resolve_security_groups
+from senza.components.auto_scaling_group import normalize_network_threshold
 from senza.components.taupage_auto_scaling_group import check_application_id, check_application_version, \
     check_docker_image_exists, generate_user_data
 from senza.utils import ensure_keys
@@ -16,8 +20,7 @@ from spotinst import MissingSpotinstAccount
 
 SPOTINST_LAMBDA_FORMATION_ARN = 'arn:aws:lambda:{}:178579023202:function:spotinst-cloudformation'
 SPOTINST_API_URL = 'https://api.spotinst.io'
-ELASTIGROUP_DEFAULT_STRATEGY = {"risk": 100, "availabilityVsCost": "balanced"}
-ELASTIGROUP_DEFAULT_CAPACITY = {"target": 1, "minimum": 1, "maximum": 1}
+ELASTIGROUP_DEFAULT_STRATEGY = {"risk": 100, "availabilityVsCost": "balanced", "utilizeReservedInstances": True}
 ELASTIGROUP_DEFAULT_PRODUCT = "Linux/UNIX"
 
 
@@ -28,30 +31,36 @@ def component_elastigroup(definition, configuration, args, info, force, account_
     - For the API reference see; http://api.spotinst.com/elastigroup/amazon-web-services/create/
     - For the CloudFormation integration see; http://blog.spotinst.com/2016/04/05/elastigroup-cloudformation/
     """
-    definition = ensure_keys(definition, "Resources")
-
-    config_name = configuration["Name"] + "Config"
+    definition = ensure_keys(ensure_keys(definition, "Resources"), "Mappings", "Senza", "Info")
+    if "SpotinstAccessToken" not in definition["Mappings"]["Senza"]["Info"]:
+        raise click.UsageError("You have to specificy your SpotinstAccessToken attribute inside the SenzaInfo "
+                               "to be able to use Elastigroups")
+    configuration = ensure_keys(configuration, "Elastigroup")
 
     # launch configuration
     elastigroup_config = configuration["Elastigroup"]
-    ensure_keys(elastigroup_config, "scaling")
     ensure_keys(elastigroup_config, "scheduling")
     ensure_keys(elastigroup_config, "thirdPartiesIntegration")
 
     fill_standard_tags(definition, elastigroup_config)
     ensure_default_strategy(elastigroup_config)
-    ensure_default_capacity(elastigroup_config)
     ensure_default_product(elastigroup_config)
     ensure_instance_monitoring(elastigroup_config)
 
     extract_subnets(definition, elastigroup_config, account_info)
     extract_user_data(configuration, elastigroup_config, info, force, account_info)
-    extract_load_balancer_name(elastigroup_config)
+    extract_load_balancer_name(configuration, elastigroup_config)
+    extract_public_ips(configuration, elastigroup_config)
     extract_image_id(elastigroup_config)
-    extract_security_group_ids(elastigroup_config, args)
-
+    extract_security_group_ids(configuration, elastigroup_config, args)
+    extract_instance_types(configuration, elastigroup_config)
+    extract_autoscaling_capacity(configuration, elastigroup_config)
+    extract_auto_scaling_rules(configuration, elastigroup_config)
+    extract_block_mappings(configuration, elastigroup_config)
+    extract_instance_profile(args, definition, configuration, elastigroup_config)
     # cfn definition
     access_token = _extract_spotinst_access_token(definition)
+    config_name = configuration["Name"] + "Config"
     definition["Resources"][config_name] = {
         "Type": "Custom::elastigroup",
         "Properties": {
@@ -62,7 +71,111 @@ def component_elastigroup(definition, configuration, args, info, force, account_
         }
     }
 
+    if "SpotPrice" in configuration:
+        print("warning: SpotPrice is ignored when using Spotinst::Elastigroup", file=sys.stderr)
     return definition
+
+
+def extract_block_mappings(configuration, elastigroup_config):
+    """
+    This function converts a Senza BlockDeviceMappings section into the matching section of the Elastigroup
+    If there's a launchSpecification.blockDeviceMappings section already it's left untouched
+    """
+    if "BlockDeviceMappings" not in configuration:
+        return
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
+    launch_spec = elastigroup_config["compute"]["launchSpecification"]
+    if "blockDeviceMappings" in launch_spec:
+        return
+    block_device_mappings = configuration.pop("BlockDeviceMappings")
+    elastigroup_mappings = []
+    for mapping in block_device_mappings:
+        elastigroup_mappings.append({
+            "deviceName": mapping["DeviceName"],
+            "ebs": {
+                "deleteOnTermination": True,
+                "volumeType": "gp2",
+                "volumeSize": mapping["Ebs"]["VolumeSize"]
+            }
+        })
+    if elastigroup_mappings:
+        launch_spec["blockDeviceMappings"] = elastigroup_mappings
+
+
+def extract_auto_scaling_rules(configuration, elastigroup_config):
+    """
+    This function will convert Senza's auto scaling settings and create the matching scaling rules
+    for the Elastigroup
+    If there's already a scaling configuration it will be left untouched
+    """
+    if "scaling" in elastigroup_config:
+        return
+    auto_scaling = configuration.get("AutoScaling", None)
+    scaling = {}
+    if auto_scaling:
+        adjustment = auto_scaling.get("ScalingAdjustment", 1)
+        cooldown = auto_scaling.get("Cooldown", 60)
+
+        # Scale up
+        scale_up_adjustment = int(auto_scaling.get("ScaleUpAdjustment", adjustment))
+        scale_up_cooldown = auto_scaling.get("ScaleUpCooldown", cooldown)
+        if "ScaleUpThreshold" in auto_scaling:
+            scaling["up"] = [create_scale_rule(auto_scaling, "gte", auto_scaling["ScaleUpThreshold"],
+                                               scale_up_adjustment, scale_up_cooldown)]
+
+        # Scale down
+        scale_down_adjustment = int(auto_scaling.get("ScaleDownAdjustment", adjustment))
+        scale_down_cooldown = auto_scaling.get("ScaleDownCooldown", cooldown)
+        if "ScaleDownThreshold" in auto_scaling:
+            scaling["down"] = [create_scale_rule(auto_scaling, "lt", auto_scaling["ScaleDownThreshold"],
+                                                 scale_down_adjustment, scale_down_cooldown)]
+
+    elastigroup_config["scaling"] = scaling
+
+
+def normalize_threshold(metric_type, threshold):
+    if metric_type.startswith("Network"):
+        normalized_threshold = normalize_network_threshold(threshold)
+        return normalized_threshold[0], normalized_threshold[1]
+    return threshold, "percent"
+
+
+def create_scale_rule(auto_scaling, operator, threshold, adjustment, cooldown):
+    metric_type = auto_scaling.get("MetricType", "CPU")
+    valid_metrics = {"CPU": "CPUUtilization", "NetworkIn": "NetworkIn", "NetworkOut": "NetworkOut"}
+    ops = {"gt": ">", "gte": ">=", "lt": "<", "lte": "<="}
+    if metric_type.lower() not in map(lambda t: t.lower(), valid_metrics.keys()):
+        raise click.UsageError('Auto scaling MetricType "{}" not supported.'.format(metric_type))
+    threshold, unit = normalize_threshold(metric_type, threshold)
+    period = int(auto_scaling.get("Period", 300))
+    evaluation_periods = int(auto_scaling.get("EvaluationPeriods", 2))
+    statistic = auto_scaling.get("Statistic", "average")
+    statistic = statistic[0].lower() + statistic[1:]  # fix case for spotinst API :(
+
+    return {
+        "policyName": "Scale if {} {} {} {} for {} minutes ({})".format(
+            metric_type,
+            ops.get(operator, "kind of"),
+            threshold,
+            unit,
+            (period / 60) * evaluation_periods,
+            statistic
+        ),
+        "metricName": valid_metrics[metric_type],
+        "statistic": statistic,
+        "unit": unit,
+        "threshold": threshold,
+        "namespace": "AWS/EC2",
+        "dimensions": [{"name": "InstanceId"}],
+        "period": period,
+        "evaluationPeriods": evaluation_periods,
+        "cooldown": cooldown,
+        "action": {
+            "type": "adjustment",
+            "adjustment": adjustment
+        },
+        "operator": operator
+    }
 
 
 def ensure_instance_monitoring(elastigroup_config):
@@ -70,6 +183,7 @@ def ensure_instance_monitoring(elastigroup_config):
     This functions will set the monitoring property to True if not set already in the compute.launchSpecification
     section. This enables EC2 enhanced monitoring, which is also the general STUPS behavior
     """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
     if "monitoring" in elastigroup_config["compute"]["launchSpecification"]:
         return
     elastigroup_config["compute"]["launchSpecification"]["monitoring"] = True
@@ -84,13 +198,25 @@ def ensure_default_strategy(elastigroup_config):
     elastigroup_config["strategy"] = ELASTIGROUP_DEFAULT_STRATEGY
 
 
-def ensure_default_capacity(elastigroup_config):
+def extract_autoscaling_capacity(configuration, elastigroup_config):
     """
-    This function will add a default capacity section if none is present. See ELASTIGROUP_DEFAULT_CAPACITY
+    This function will set the Spotinst capacity from the Senza AutoScaling settings.
+    It will add a default capacity of 1 if none is present.
+    The target capacity will be adjusted to be within the minimum and maximum boundaries
+    If there's already a capacity section it will be left untouched
     """
     if "capacity" in elastigroup_config:
         return
-    elastigroup_config["capacity"] = ELASTIGROUP_DEFAULT_CAPACITY
+    auto_scaling = configuration.get("AutoScaling", None)
+    target = 1
+    minimum = 1
+    maximum = 1
+    if auto_scaling:
+        minimum = int(auto_scaling.get("Minimum", minimum))
+        maximum = int(auto_scaling.get("Maximum", maximum))
+        target = min(max(minimum, int(auto_scaling.get("DesiredCapacity", 1))), maximum)
+
+    elastigroup_config["capacity"] = {"target": target, "minimum": minimum, "maximum": maximum}
 
 
 def ensure_default_product(elastigroup_config):
@@ -98,6 +224,7 @@ def ensure_default_product(elastigroup_config):
     This function ensures that the compute.product attribute for the Elastigroup is defined with a default value.
     See ELASTIGROUP_DEFAULT_PRODUCT
     """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute")
     if "product" in elastigroup_config["compute"]:
         return
     elastigroup_config["compute"]["product"] = ELASTIGROUP_DEFAULT_PRODUCT
@@ -106,34 +233,34 @@ def ensure_default_product(elastigroup_config):
 def fill_standard_tags(definition, elastigroup_config):
     """
     This function adds the default STUPS EC2 Tags when none are defined in the Elastigroup. It also sets the
-    Elastigroup name attribute to the same value as the EC2 Name tag.
+    Elastigroup name attribute to the same value as the EC2 Name tag if found empty.
     The default STUPS EC2 Tags are Name, StackName and StackVersion
     """
-    if "tags" in elastigroup_config["compute"]["launchSpecification"]:
-        return
-
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
     name = definition["Mappings"]["Senza"]["Info"]["StackName"]
     version = definition["Mappings"]["Senza"]["Info"]["StackVersion"]
     full_name = "{}-{}".format(name, version)
-    elastigroup_config["compute"]["launchSpecification"]["tags"] = [
-        {"tagKey": "Name", "tagValue": full_name},
-        {"tagKey": "StackName", "tagValue": name},
-        {"tagKey": "StackVersion", "tagValue": version}
-    ]
+
+    if "tags" not in elastigroup_config["compute"]["launchSpecification"]:
+        elastigroup_config["compute"]["launchSpecification"]["tags"] = [
+            {"tagKey": "Name", "tagValue": full_name},
+            {"tagKey": "StackName", "tagValue": name},
+            {"tagKey": "StackVersion", "tagValue": version}
+        ]
     if elastigroup_config.get("name", "") == "":
         elastigroup_config["name"] = full_name
 
 
 def extract_subnets(definition, elastigroup_config, account_info):
     """
-    This fills in the subnetIds and region attributes of the Spotinst elastigroup, in case their not defined already
+    This fills in the subnetIds and region attributes of the Spotinst elastigroup, in case they're not defined already
     The subnetIds are discovered by Senza::StupsAutoConfiguration and the region is provided by the AccountInfo object
     """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute")
     subnet_ids = elastigroup_config["compute"].get("subnetIds", [])
     target_region = elastigroup_config.get("region", account_info.Region)
     if not subnet_ids:
-        subnet_ids = [subnetId for subnetId in
-                      definition["Mappings"]["ServerSubnets"].get(target_region, {}).get("Subnets", [])]
+        subnet_ids = definition["Mappings"]["ServerSubnets"].get(target_region, {}).get("Subnets", [])
     elastigroup_config["region"] = target_region
     elastigroup_config["compute"]["subnetIds"] = subnet_ids
 
@@ -143,8 +270,10 @@ def extract_user_data(configuration, elastigroup_config, info: dict, force, acco
     This function converts a classic TaupageConfig into a base64 encoded value for the
     compute.launchSpecification.userData
     See https://api.spotinst.com/elastigroup/amazon-web-services/create/#compute.launchSpecification.userData
+    Any existing TaupageConfig will _always_ overwrite the userData for the Elastigroup
     """
-    taupage_config = configuration.get("TaupageConfig", {})
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
+    taupage_config = configuration.get("TaupageConfig", None)
     if taupage_config:
         if 'notify_cfn' not in taupage_config:
             taupage_config['notify_cfn'] = {'stack': '{}-{}'.format(info["StackName"], info["StackVersion"]),
@@ -176,62 +305,107 @@ def extract_user_data(configuration, elastigroup_config, info: dict, force, acco
         elastigroup_config["compute"]["launchSpecification"]["userData"] = user_data.decode('utf-8')
 
 
-def extract_load_balancer_name(elastigroup_config: dict):
+def extract_load_balancer_name(configuration, elastigroup_config: dict):
     """
-    This function identifies whether a senza ELB-Classic is configured,
+    This function identifies whether a senza ELB is configured,
     if so it transforms it into a Spotinst Elastigroup balancer API configuration
-
+    If there's already a Spotinst launchSpecification present it is left untouched
+    It also handles the health check definitions (type and grace period) giving precedence to any existing Elastigroup
+    defintions.
     """
-    load_balancers = []
 
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
     launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
+    health_check_type = "EC2"
 
     if "loadBalancersConfig" not in launch_spec_config.keys():
-        if "ElasticLoadBalancer" in launch_spec_config.keys():
+        load_balancers = []
 
-            load_balancer_refs = launch_spec_config.pop("ElasticLoadBalancer")
+        if "ElasticLoadBalancer" in configuration:
+            load_balancer_refs = configuration.pop("ElasticLoadBalancer")
             if isinstance(load_balancer_refs, str):
                 load_balancers.append({
                     "name": {"Ref": load_balancer_refs},
                     "type": "CLASSIC"
                 })
-
             elif isinstance(load_balancer_refs, list):
                 for load_balancer_ref in load_balancer_refs:
                     load_balancers.append({
                         "name": {"Ref": load_balancer_ref},
                         "type": "CLASSIC"
                     })
+        if "ElasticLoadBalancerV2" in configuration:
+            load_balancer_refs = configuration.pop("ElasticLoadBalancerV2")
+            if isinstance(load_balancer_refs, str):
+                load_balancers.append({
+                    "arn": {"Ref": load_balancer_refs + 'TargetGroup'},
+                    "type": "TARGET_GROUP"
+                })
+            elif isinstance(load_balancer_refs, list):
+                for load_balancer_ref in load_balancer_refs:
+                    load_balancers.append({
+                        "arn": {"Ref": load_balancer_ref + "TargetGroup"},
+                        "type": "TARGET_GROUP"
+                    })
 
         if len(load_balancers) > 0:
+            # use ELB health check by default when there are LBs
+            health_check_type = "ELB"
             launch_spec_config["loadBalancersConfig"] = {"loadBalancers": load_balancers}
+
+    if "healthCheckType" in launch_spec_config:
+        health_check_type = launch_spec_config["healthCheckType"]
+    elif "HealthCheckType" in configuration:
+        health_check_type = configuration["HealthCheckType"]
+    launch_spec_config["healthCheckType"] = health_check_type
+    grace_period = launch_spec_config.get("healthCheckGracePeriod", configuration.get('HealthCheckGracePeriod', 300))
+    launch_spec_config["healthCheckGracePeriod"] = grace_period
+
+
+def extract_public_ips(configuration, elastigroup_config):
+    """
+    This function will setup the Spotinst Elastigroup to use Public IPs if the
+    Senza AssociatePublicIpAddress is set to True.
+    If there's already a compute.launchSpecification.networkInterfaces config it is left untouched
+    """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
+    if configuration.pop("AssociatePublicIpAddress", False):
+        launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
+        if "networkInterfaces" not in launch_spec_config.keys():
+            launch_spec_config["networkInterfaces"] = [
+                {
+                    "deleteOnTermination": True,
+                    "deviceIndex": 0,
+                    "associatePublicIpAddress": True
+                }
+            ]
 
 
 def extract_image_id(elastigroup_config: dict):
     """
     This function identifies whether a senza formatted AMI mapping is configured,
     if so it transforms it into a Spotinst Elastigroup AMI API configuration
-
     """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
     launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
 
     if "imageId" not in launch_spec_config.keys():
         launch_spec_config["imageId"] = {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "LatestTaupageImage"]}
 
 
-def extract_security_group_ids(elastigroup_config: dict, args):
+def extract_security_group_ids(configuration, elastigroup_config: dict, args):
     """
     This function identifies whether a senza formatted EC2-sg (by name) is configured,
     if so it transforms it into a Spotinst Elastigroup EC2-sq (by id) API configuration
-
+    If there's already a compute.launchSpecification.securityGroupIds config it's left unchanged
     """
-    security_group_ids = []
-
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
     launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
 
+    security_group_ids = []
     if "securityGroupIds" not in launch_spec_config.keys():
-        if "SecurityGroups" in launch_spec_config.keys():
-            security_groups_ref = launch_spec_config.pop("SecurityGroups")
+        if "SecurityGroups" in configuration.keys():
+            security_groups_ref = configuration.pop("SecurityGroups")
 
             if isinstance(security_groups_ref, str):
                 security_group_ids = resolve_security_groups([security_groups_ref], args.region)
@@ -241,6 +415,57 @@ def extract_security_group_ids(elastigroup_config: dict, args):
 
             if len(security_group_ids) > 0:
                 launch_spec_config["securityGroupIds"] = security_group_ids
+
+
+def extract_instance_types(configuration, elastigroup_config):
+    """
+    This function will set up the Elastigroup instance type, both for on-demand and spot. If there
+    are no SpotAlternatives the Elastigroup will have the same ondemand type as spot alternative
+    If there's already a compute.instanceTypes config it will be left untouched
+    """
+    elastigroup_config = ensure_keys(ensure_keys(elastigroup_config, "strategy"), "compute")
+    compute_config = elastigroup_config["compute"]
+    instance_type = configuration.pop("InstanceType", None)
+    spot_alternatives = configuration.pop("SpotAlternatives", None)
+    if "instanceTypes" not in compute_config:
+        if not (instance_type or spot_alternatives):
+            raise click.UsageError("You have to specify one of InstanceType or SpotAlternatives")
+        instance_types = {}
+        strategy = elastigroup_config["strategy"]
+        if instance_type:
+            instance_types.update({"ondemand": instance_type})
+            strategy.update({"fallbackToOd": True})
+        else:
+            strategy.update({"fallbackToOd": False})
+        if spot_alternatives:
+            instance_types.update({"spot": spot_alternatives})
+        else:
+            instance_types.update({"spot": [instance_type]})
+        compute_config["instanceTypes"] = instance_types
+
+
+def extract_instance_profile(args, definition, configuration, elastigroup_config):
+    """
+    Resolves the Senza IAM role or instance profile into the appropriate Spotinst launchSpecification.iamRole
+    settings.
+    If only IAM roles are specified, a new instance profile is created and the Elastigroup definition will have a
+    reference to the newly created instance profile.
+    If the launchSpecification already has the iamRole defined it is left untouched
+    When the Senza manifest includes both the IAMRoles and the IamInstanceProfile attributes the IAMRoles takes
+    precedence.
+    The IamInstanceProfile can specify either the ARN or just the instance profile name. This function will accept both
+    """
+    elastigroup_config = ensure_keys(elastigroup_config, "compute", "launchSpecification")
+    launch_spec = elastigroup_config["compute"]["launchSpecification"]
+    if "iamRole" in launch_spec:
+        return
+    if "IamRoles" in configuration:
+        logical_id = senza.components.auto_scaling_group.handle_iam_roles(definition, configuration, args)
+        launch_spec["iamRole"] = {"name": {"Ref": logical_id}}
+    elif "IamInstanceProfile" in configuration:
+        logical_id = configuration["IamInstanceProfile"]
+        attribute = "arn" if logical_id.startswith("arn:aws:iam::") else "name"
+        launch_spec["iamRole"] = {attribute: logical_id}
 
 
 def create_service_token(region: str):
@@ -262,7 +487,7 @@ def extract_spotinst_account_id(access_token: str, definition: dict, account_inf
     if present, return the template defined Spotinst target account id or use the Spotinst API to
     list the accounts and return the first account found
     """
-    template_account_id = definition["Mappings"]["Senza"]["Info"].get("SpotinstAccountId", "")
+    template_account_id = definition["Mappings"]["Senza"]["Info"].get("SpotinstAccountId")
     if not template_account_id:
         template_account_id = resolve_account_id(access_token, account_info)
     return template_account_id
@@ -287,6 +512,7 @@ def resolve_account_id(access_token, account_info):
     data = response.json()
     accounts = data.get("response", {}).get("items", [])
     for account in accounts:
+        # acounts are expected to be named with the pattern aws:123 where 123 is the actual accountId
         account_id = re.sub(r"(?i)^aws:", "", account["name"])
         if account_info.AccountID == account_id:
             return account["accountId"]

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -1,28 +1,27 @@
+import click
 import pytest
-import requests
 import responses
 from mock import MagicMock
+
 from senza.definitions import AccountArguments
 from spotinst import MissingSpotinstAccount
 from spotinst.components.elastigroup import component_elastigroup, ELASTIGROUP_DEFAULT_PRODUCT, \
-    ELASTIGROUP_DEFAULT_STRATEGY, ELASTIGROUP_DEFAULT_CAPACITY, resolve_account_id, SPOTINST_API_URL
+    ELASTIGROUP_DEFAULT_STRATEGY, resolve_account_id, SPOTINST_API_URL, extract_block_mappings, \
+    extract_auto_scaling_rules, ensure_instance_monitoring, ensure_default_strategy, extract_autoscaling_capacity, \
+    ensure_default_product, fill_standard_tags, extract_subnets, extract_load_balancer_name, extract_public_ips, \
+    extract_image_id, extract_security_group_ids, extract_instance_types, extract_instance_profile
 
 
 def test_component_elastigroup_defaults(monkeypatch):
     configuration = {
         "Name": "eg1",
-        "Elastigroup": {
-            "compute": {
-                "instanceTypes": {
-                    "ondemand": "big",
-                    "spot": ["smaller", "small"]
-                },
-                "launchSpecification": {
-                    "SecurityGroups": "sg1",
-                    "ElasticLoadBalancer": "lb1"
-                }
-            }
-        }
+        "SecurityGroups": "sg1",
+        "InstanceType": "big",
+        "SpotAlternatives": [
+            "smaller",
+            "small",
+            "small-ish"
+        ]
     }
     args = MagicMock()
     args.region = "reg1"
@@ -44,7 +43,10 @@ def test_component_elastigroup_defaults(monkeypatch):
 
     properties = result["Resources"]["eg1Config"]["Properties"]
     assert properties["accountId"] == 'act-12345abcdef'
-    assert properties["group"]["capacity"] == ELASTIGROUP_DEFAULT_CAPACITY
+    assert properties["group"]["capacity"] == {"target": 1, "minimum": 1, "maximum": 1}
+    instance_types = properties["group"]["compute"]["instanceTypes"]
+    assert instance_types["ondemand"] == "big"
+    assert instance_types["spot"] >= ["smaller", "small", "small-ish"]
     launch_specification = properties["group"]["compute"]["launchSpecification"]
     assert launch_specification["monitoring"]
     assert launch_specification["securityGroupIds"] == ["sg1"]
@@ -60,6 +62,11 @@ def test_component_elastigroup_defaults(monkeypatch):
     assert "scaling" in properties["group"]
     assert "scheduling" in properties["group"]
     assert "thirdPartiesIntegration" in properties["group"]
+
+
+def test_missing_access_token():
+    with pytest.raises(click.UsageError):
+        component_elastigroup({}, {}, MagicMock(), MagicMock(), False, MagicMock())
 
 
 def test_spotinst_account_resolution():
@@ -79,16 +86,586 @@ def test_spotinst_account_resolution():
 
 
 def test_spotinst_account_resolution_failure():
-    with pytest.raises(MissingSpotinstAccount):
-        mock_info = MagicMock()
-        mock_info.AccountID = "12345"
-        with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, '{}/setup/account/'.format(SPOTINST_API_URL), status=200,
-                     json={"response": {
-                         "items": [
-                             {"accountId": "act-foo", "name": "aws:xyz"},
-                             {"accountId": "act-bar", "name": "aws:zbr"}
-                         ],
-                     }})
+    mock_info = MagicMock()
+    mock_info.AccountID = "12345"
+    with responses.RequestsMock() as rsps:
+        rsps.add(rsps.GET, '{}/setup/account/'.format(SPOTINST_API_URL), status=200,
+                 json={"response": {
+                     "items": [
+                         {"accountId": "act-foo", "name": "aws:xyz"},
+                         {"accountId": "act-bar", "name": "aws:zbr"}
+                     ],
+                 }})
 
+        with pytest.raises(MissingSpotinstAccount):
             resolve_account_id("fake-token", mock_info)
+
+
+def test_block_mappings():
+    test_cases = [
+        {  # leave elastigroup settings untouched
+            "input": {},
+            "given_config": {},
+            "expected_config": {}
+        },
+        {  # leave elastigroup blockDeviceMappings untouched
+            "input": {},
+            "given_config": {"compute": {"launchSpecification": {"blockDeviceMappings": {"foo": "bar"}}}},
+            "expected_config": {"compute": {"launchSpecification": {"blockDeviceMappings": {"foo": "bar"}}}},
+        },
+        {  # Keep Spotinst defs when there are Senza defs
+            "input": {"BlockDeviceMappings": [{"DeviceName": "/dev/sda1"}]},
+            "given_config": {"compute": {"launchSpecification": {"blockDeviceMappings": {"foo": "bar"}}}},
+            "expected_config": {"compute": {"launchSpecification": {"blockDeviceMappings": {"foo": "bar"}}}},
+        },
+        {  # convert Senza defs to Spotinst
+            "input": {"BlockDeviceMappings": [{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 42}}]},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"blockDeviceMappings": [{
+                "deviceName": "/dev/sda1",
+                "ebs": {
+                    "deleteOnTermination": True,
+                    "volumeType": "gp2",
+                    "volumeSize": 42
+                }
+            }]}}},
+        },
+    ]
+
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_block_mappings(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_auto_scaling_rules():
+    test_cases = [
+        {  # leave elastigroup settings untouched
+            "input": {},
+            "given_config": {},
+            "expected_config": {"scaling": {}}
+        },
+        {  # leave elastigroup scaling section untouched
+            "input": {},
+            "given_config": {"compute": {}, "scaling": {"down": {}, "up": {}}},
+            "expected_config": {"compute": {}, "scaling": {"down": {}, "up": {}}},
+        },
+        {  # Keep Spotinst defs when there are Senza defs
+            "input": {"AutoScaling": {"ScaleUpThreshold": 42, "ScalingAdjustment": 9, "Cooldown": 42}},
+            "given_config": {"compute": {}, "scaling": {}},
+            "expected_config": {"compute": {}, "scaling": {}},
+        },
+        {  # convert Senza defs with scale up only
+            "input": {
+                "AutoScaling": {
+                    "ScaleUpThreshold": 42,
+                    "ScalingAdjustment": 9,
+                    "Cooldown": 42
+                }
+            },
+            "given_config": {},
+            "expected_config": {"scaling": {
+                "up": [{
+                    "policyName": "Scale if CPU >= 42 percent for 10.0 minutes (average)",
+                    "metricName": "CPUUtilization",
+                    "statistic": "average",
+                    "unit": "percent",
+                    "threshold": 42,
+                    "namespace": "AWS/EC2",
+                    "dimensions": [{"name": "InstanceId"}],
+                    "period": 300,
+                    "evaluationPeriods": 2,
+                    "cooldown": 42,
+                    "action": {"type": "adjustment", "adjustment": 9},
+                    "operator": "gte"
+                }]
+            }},
+        },
+        {  # convert Senza defs with scale down network
+            "input": {
+                "AutoScaling": {
+                    "ScaleDownThreshold": "42 GB",
+                    "Period": 60,
+                    "EvaluationPeriods": 1,
+                    "ScalingAdjustment": 9,
+                    "MetricType": "NetworkIn"
+                }
+            },
+            "given_config": {},
+            "expected_config": {"scaling": {
+                "down": [{
+                    "policyName": "Scale if NetworkIn < 42 Gigabytes for 1.0 minutes (average)",
+                    "metricName": "NetworkIn",
+                    "statistic": "average",
+                    "unit": "Gigabytes",
+                    "threshold": "42",
+                    "namespace": "AWS/EC2",
+                    "dimensions": [{"name": "InstanceId"}],
+                    "period": 60,
+                    "evaluationPeriods": 1,
+                    "cooldown": 60,
+                    "action": {"type": "adjustment", "adjustment": 9},
+                    "operator": "lt"
+                }]
+            }},
+        },
+    ]
+
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_auto_scaling_rules(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_detailed_monitoring():
+    test_cases = [
+        {  # set default monitoring option
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"monitoring": True}}}
+        },
+        {  # leave monitoring untouched
+            "given_config": {"compute": {"launchSpecification": {"monitoring": "fake"}}},
+            "expected_config": {"compute": {"launchSpecification": {"monitoring": "fake"}}}
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        ensure_instance_monitoring(got)
+        assert test_case["expected_config"] == got
+
+
+def test_prediction_strategy():
+    test_cases = [
+        {  # default prediction strategy
+            "given_config": {},
+            "expected_config": {"strategy": ELASTIGROUP_DEFAULT_STRATEGY}
+        },
+        {  # leave strategy untouched
+            "given_config": {"strategy": "fake"},
+            "expected_config": {"strategy": "fake"}
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        ensure_default_strategy(got)
+        assert test_case["expected_config"] == got
+
+
+def test_autoscaling_capacity():
+    test_cases = [
+        {  # default prediction strategy
+            "input": {},
+            "given_config": {},
+            "expected_config": {"capacity": {"target": 1, "minimum": 1, "maximum": 1}}
+        },
+        {  # leave strategy untouched
+            "input": {"AutoScaling": {"DesiredCapacity": 42}},
+            "given_config": {"capacity": "fake"},
+            "expected_config": {"capacity": "fake"}
+        },
+        {  # convert senza capacity
+            "input": {"AutoScaling": {"DesiredCapacity": 42, "Maximum": 69}},
+            "given_config": {},
+            "expected_config": {"capacity": {"target": 42, "minimum": 1, "maximum": 69}}
+        },
+        {  # convert senza capacity and adjust desired to min
+            "input": {"AutoScaling": {"DesiredCapacity": 1, "Minimum": 2, "Maximum": 42}},
+            "given_config": {},
+            "expected_config": {"capacity": {"target": 2, "minimum": 2, "maximum": 42}}
+        },
+        {  # convert senza capacity and adjust desired to max
+            "input": {"AutoScaling": {"DesiredCapacity": 69, "Minimum": 2, "Maximum": 42}},
+            "given_config": {},
+            "expected_config": {"capacity": {"target": 42, "minimum": 2, "maximum": 42}}
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_autoscaling_capacity(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_product():
+    test_cases = [
+        {  # default product
+            "given_config": {},
+            "expected_config": {"compute": {"product": ELASTIGROUP_DEFAULT_PRODUCT}},
+        },
+        {  # leave product untouched
+            "given_config": {"compute": {"product": "fake"}},
+            "expected_config": {"compute": {"product": "fake"}},
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        ensure_default_product(got)
+        assert test_case["expected_config"] == got
+
+
+def test_standard_tags():
+    test_cases = [
+        {  # default tags
+            "definition": {"Mappings": {"Senza": {"Info": {"StackName": "foo", "StackVersion": "bar"}}}},
+            "given_config": {},
+            "expected_config": {
+                "compute": {
+                    "launchSpecification": {
+                        "tags": [
+                            {"tagKey": "Name", "tagValue": "foo-bar"},
+                            {"tagKey": "StackName", "tagValue": "foo"},
+                            {"tagKey": "StackVersion", "tagValue": "bar"},
+                        ]},
+                },
+                "name": "foo-bar",
+            },
+        },
+        {  # leave tags untouched
+            "definition": {"Mappings": {"Senza": {"Info": {"StackName": "foo", "StackVersion": "bar"}}}},
+            "given_config": {"compute": {"launchSpecification": {"tags": "fake"}}},
+            "expected_config": {
+                "compute": {
+                    "launchSpecification": {
+                        "tags": "fake"},
+                },
+                "name": "foo-bar",
+            },
+        },
+        {  # leave name untouched
+            "definition": {"Mappings": {"Senza": {"Info": {"StackName": "foo", "StackVersion": "bar"}}}},
+            "given_config": {"name": "must-stay-untouched"},
+            "expected_config": {
+                "compute": {
+                    "launchSpecification": {
+                        "tags": [
+                            {"tagKey": "Name", "tagValue": "foo-bar"},
+                            {"tagKey": "StackName", "tagValue": "foo"},
+                            {"tagKey": "StackVersion", "tagValue": "bar"},
+                        ],
+                    },
+                },
+                "name": "must-stay-untouched",
+            },
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        fill_standard_tags(test_case["definition"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_extract_subnets():
+    test_cases = [
+        {  # use auto discovered subnets from auto-discovered region
+            "definition": {"Mappings": {"ServerSubnets": {"reg1": {"Subnets": ["sn1", "sn2"]}}}},
+            "given_config": {},
+            "expected_config": {"compute": {"subnetIds": ["sn1", "sn2"]}, "region": "reg1"},
+        },
+        {  # use auto discovered subnets from specified region
+            "definition": {"Mappings": {"ServerSubnets": {
+                "reg1": {"Subnets": ["sn1", "sn2"]},
+                "reg2": {"Subnets": ["n1", "n2"]}
+            }}},
+            "given_config": {"region": "reg2"},
+            "expected_config": {"compute": {"subnetIds": ["n1", "n2"]}, "region": "reg2"},
+        },
+        {  # leave subnetIds untouched
+            "definition": {"Mappings": {"ServerSubnets": {"reg1": {"Subnets": ["sn1", "sn2"]}}}},
+            "given_config": {"compute": {"subnetIds": ["subnet01"]}},
+            "expected_config": {"compute": {"subnetIds": ["subnet01"]}, "region": "reg1"},
+        },
+    ]
+    account_info = MagicMock()
+    account_info.Region = "reg1"
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_subnets(test_case["definition"], got, account_info)
+        assert test_case["expected_config"] == got
+
+
+def test_load_balancers():
+    test_cases = [
+        {  # no load balancers, default healthcheck
+            "input": {},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"healthCheckType": "EC2",
+                                                                    "healthCheckGracePeriod": 300}}},
+        },
+        {  # no load balancers, Taupage's healthcheck type, default grace period
+            "input": {"HealthCheckType": "FAKE"},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"healthCheckType": "FAKE",
+                                                                    "healthCheckGracePeriod": 300}}},
+        },
+        {  # no load balancers, Taupage's healthcheck type and grace period
+            "input": {"HealthCheckType": "FAKE", "HealthCheckGracePeriod": 42},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"healthCheckType": "FAKE",
+                                                                    "healthCheckGracePeriod": 42}}},
+        },
+        {  # no load balancers, Elastigroup's healthcheck type and default grace period
+            "input": {},
+            "given_config": {"compute": {"launchSpecification": {"healthCheckType": "EG-FAKE"}}},
+            "expected_config": {"compute": {"launchSpecification": {"healthCheckType": "EG-FAKE",
+                                                                    "healthCheckGracePeriod": 300}}},
+        },
+        {  # no load balancers, Elastigroup's healthcheck type and grace period
+            "input": {},
+            "given_config": {"compute": {"launchSpecification": {"healthCheckType": "EG-FAKE",
+                                                                 "healthCheckGracePeriod": 42}}},
+            "expected_config": {"compute": {"launchSpecification": {"healthCheckType": "EG-FAKE",
+                                                                    "healthCheckGracePeriod": 42}}},
+        },
+        {  # 1 classic load balancer from Taupage, healthcheck type set to ELB (default grace period)
+            "input": {"ElasticLoadBalancer": "foo"},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"name": {"Ref": "foo"}, "type": "CLASSIC"},
+                    ],
+                },
+                "healthCheckType": "ELB",
+                "healthCheckGracePeriod": 300,
+            }}},
+        },
+        {  # multiple classic load balancers from Taupage, healthcheck type set to ELB (default grace period)
+            "input": {"ElasticLoadBalancer": ["foo", "bar"]},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"name": {"Ref": "foo"}, "type": "CLASSIC"},
+                        {"name": {"Ref": "bar"}, "type": "CLASSIC"},
+                    ],
+                },
+                "healthCheckType": "ELB",
+                "healthCheckGracePeriod": 300,
+            }}},
+        },
+        {  # 1 application load balancer from Taupage, healthcheck type set to ELB (default grace period)
+            "input": {"ElasticLoadBalancerV2": "bar"},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"arn": {"Ref": "barTargetGroup"}, "type": "TARGET_GROUP"},
+                    ],
+                },
+                "healthCheckType": "ELB",
+                "healthCheckGracePeriod": 300,
+            }}},
+        },
+        {  # multiple application load balancers from Taupage, healthcheck type set to ELB (default grace period)
+            "input": {"ElasticLoadBalancerV2": ["foo", "bar"]},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"arn": {"Ref": "fooTargetGroup"}, "type": "TARGET_GROUP"},
+                        {"arn": {"Ref": "barTargetGroup"}, "type": "TARGET_GROUP"},
+                    ],
+                },
+                "healthCheckType": "ELB",
+                "healthCheckGracePeriod": 300,
+            }}},
+        },
+        {  # mixed load balancers from Taupage, healthcheck type set to ELB and custom Taupage grace period
+            "input": {
+                "ElasticLoadBalancer": "foo",
+                "ElasticLoadBalancerV2": "bar",
+                "HealthCheckGracePeriod": 42
+            },
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"name": {"Ref": "foo"}, "type": "CLASSIC"},
+                        {"arn": {"Ref": "barTargetGroup"}, "type": "TARGET_GROUP"},
+                    ],
+                },
+                "healthCheckType": "ELB",
+                "healthCheckGracePeriod": 42,
+            }}},
+        },
+        {  # 1 load balancer from Taupage, healthcheck type and grace period set in Taupage
+            "input": {
+                "ElasticLoadBalancer": "foo",
+                "HealthCheckType": "FAKE",
+                "HealthCheckGracePeriod": 42
+            },
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "loadBalancersConfig": {
+                    "loadBalancers": [
+                        {"name": {"Ref": "foo"}, "type": "CLASSIC"},
+                    ],
+                },
+                "healthCheckType": "FAKE",
+                "healthCheckGracePeriod": 42,
+            }}},
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_load_balancer_name(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_public_ips():
+    test_cases = [
+        {  # default behavior - no public IPs, leave untouched
+            "input": {},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {}}},
+        },
+        {  # set networkInterfaces when public IP requested in Taupage
+            "input": {"AssociatePublicIpAddress": True},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {"networkInterfaces": [{
+                "deleteOnTermination": True,
+                "deviceIndex": 0,
+                "associatePublicIpAddress": True,
+            }]}}},
+        },
+        {  # leave networkInterfaces untouched
+            "input": {"AssociatePublicIpAddress": True},
+            "given_config": {"compute": {"launchSpecification": {"networkInterfaces": "fake"}}},
+            "expected_config": {"compute": {"launchSpecification": {"networkInterfaces": "fake"}}},
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_public_ips(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_extract_image_id():
+    test_cases = [
+        {  # default behavior - set latest taupage image
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "imageId": {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "LatestTaupageImage"]}
+            }}},
+        },
+        {  # leave imageId untouched
+            "given_config": {"compute": {"launchSpecification": {"imageId": "fake-id"}}},
+            "expected_config": {"compute": {"launchSpecification": {"imageId": "fake-id"}}},
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_image_id(got)
+        assert test_case["expected_config"] == got
+
+
+def test_extract_security_group_ids(monkeypatch):
+    test_cases = [
+        {  # default behavior - no particular security groups
+            "input": {},
+            "given_config": {},
+            "expected_sgs": None,
+        },
+        {  # extract single security group
+            "input": {"SecurityGroups": "foo"},
+            "given_config": {},
+            "expected_sgs": ["foo"],
+        },
+        {  # extract multiple security groups
+            "input": {"SecurityGroups": ["foo", "bar"]},
+            "given_config": {},
+            "expected_sgs": ["foo", "bar"],
+        },
+        {  # leave securityGroupsIds untouched
+            "input": {"SecurityGroups": ["foo", "bar"]},
+            "given_config": {"compute": {"launchSpecification": {"securityGroupIds": "fake-sg"}}},
+            "expected_sgs": "fake-sg",
+        },
+    ]
+    with monkeypatch.context() as m:
+        for test_case in test_cases:
+            mock_args = MagicMock()
+            mock_args.region = "reg1"
+            mock_sg = MagicMock()
+            mock_sg.return_value = test_case["input"].get("SecurityGroups", None)
+
+            def mock_resolve_security_group(sg, region):
+                return sg
+
+            m.setattr('senza.aws.resolve_security_group', mock_resolve_security_group)
+
+            got = test_case["given_config"]
+            extract_security_group_ids(test_case["input"], got, mock_args)
+            assert test_case["expected_sgs"] == got["compute"]["launchSpecification"].get("securityGroupIds")
+
+
+def test_missing_instance_types():
+    with pytest.raises(click.UsageError):
+        extract_instance_types({}, {})
+
+
+def test_extract_instance_types():
+    test_cases = [
+        {  # minimum accepted behavior, on demand instance type from typical Senza
+            "input": {"InstanceType": "foo"},
+            "given_config": {},
+            "expected_config": {"compute": {"instanceTypes": {"ondemand": "foo", "spot": ["foo"]}},
+                                "strategy": {"fallbackToOd": True}},
+        },
+        {  # both on demand instance type from typical Senza and spot alternatives specified
+            "input": {"InstanceType": "foo", "SpotAlternatives": ["bar", "baz"]},
+            "given_config": {},
+            "expected_config": {"compute": {"instanceTypes": {"ondemand": "foo", "spot": ["bar", "baz"]}},
+                                "strategy": {"fallbackToOd": True}},
+        },
+        {  # only spot alternatives specified
+            "input": {"SpotAlternatives": ["foo", "bar"]},
+            "given_config": {},
+            "expected_config": {"compute": {"instanceTypes": {"spot": ["foo", "bar"]}},
+                                "strategy": {"fallbackToOd": False}},
+        },
+    ]
+    for test_case in test_cases:
+        got = test_case["given_config"]
+        extract_instance_types(test_case["input"], got)
+        assert test_case["expected_config"] == got
+
+
+def test_extract_instance_profile(monkeypatch):
+    test_cases = [
+        {  # no roles specified
+            "input": {},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {}}},
+        },
+        {  # leave Elastigroup iamRoles untouched
+            "input": {"IamRoles": "foo", "IamInstanceProfile": "bar"},
+            "given_config": {"compute": {"launchSpecification": {"iamRole": "fake-role"}}},
+            "expected_config": {"compute": {"launchSpecification": {"iamRole": "fake-role"}}},
+        },
+        {  # convert Senza IAMRoles to iamRole
+            "input": {"IamRoles": "foo"},
+            "given_config": {},
+            "expected_config": {"compute": {
+                "launchSpecification": {"iamRole": {"name": {"Ref": "foo"}}}}},
+        },
+        {  # convert Senza IamInstanceProfile name to iamRole
+            "input": {"IamInstanceProfile": "foo"},
+            "given_config": {},
+            "expected_config": {"compute": {
+                "launchSpecification": {"iamRole": {"name": "foo"}}}},
+        },
+        {  # convert Senza IamInstanceProfile ARN to iamRole
+            "input": {"IamInstanceProfile": "arn:aws:iam::12345667:instance-profile/foo"},
+            "given_config": {},
+            "expected_config": {"compute": {
+                "launchSpecification": {"iamRole": {"arn": "arn:aws:iam::12345667:instance-profile/foo"}}}},
+        },
+    ]
+    with monkeypatch.context() as m:
+        for test_case in test_cases:
+            mock_handle_iam_roles = MagicMock()
+            mock_handle_iam_roles.return_value = test_case["input"].get("IamRoles")
+            m.setattr("senza.components.auto_scaling_group.handle_iam_roles", mock_handle_iam_roles)
+            got = test_case["given_config"]
+            extract_instance_profile(MagicMock(), MagicMock(), test_case["input"], got)
+            assert test_case["expected_config"] == got


### PR DESCRIPTION
This should bring Spotinst's Elastigroup to feature parity with native AWS Auto Scaling Groups.

It also changes the syntax to reuse all of the ASG settings while allowing the more advanced Elastigroup API definition, which takes precedence whenever defined.