### PR TITLE
refactored Spotinst cloud account matching

### DIFF
--- a/spotinst/components/elastigroup.py
+++ b/spotinst/components/elastigroup.py
@@ -3,14 +3,13 @@ Functions to create Spotinst Elastigroups
 """
 
 import base64
-import re
 import sys
 
 import click
 import pierone
 import requests
-import senza
 
+import senza
 from senza.aws import resolve_security_groups
 from senza.components.auto_scaling_group import normalize_network_threshold
 from senza.components.taupage_auto_scaling_group import check_application_id, check_application_version, \

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -70,35 +70,28 @@ def test_missing_access_token():
 
 
 def test_spotinst_account_resolution():
-    mock_info = MagicMock()
-    mock_info.AccountID = "12345"
     with responses.RequestsMock() as rsps:
-        rsps.add(rsps.GET, '{}/setup/account/'.format(SPOTINST_API_URL), status=200,
+        rsps.add(rsps.GET, '{}/setup/account?awsAccountId=12345'.format(SPOTINST_API_URL), status=200,
                  json={"response": {
                      "items": [
-                         {"accountId": "act-1234abcd", "name": "aws:" + mock_info.AccountID},
-                         {"accountId": "act-xyz", "name": "aws:54321"}
+                         {"accountId": "act-1234abcd", "name": "expected-match"},
+                         {"accountId": "act-xyz", "name": "second-match"}
                      ],
                  }})
 
-        account_id = resolve_account_id("fake-token", mock_info)
+        account_id = resolve_account_id("fake-token", "12345")
         assert account_id == "act-1234abcd"
 
 
 def test_spotinst_account_resolution_failure():
-    mock_info = MagicMock()
-    mock_info.AccountID = "12345"
     with responses.RequestsMock() as rsps:
-        rsps.add(rsps.GET, '{}/setup/account/'.format(SPOTINST_API_URL), status=200,
+        rsps.add(rsps.GET, '{}/setup/account?awsAccountId=12345'.format(SPOTINST_API_URL), status=200,
                  json={"response": {
-                     "items": [
-                         {"accountId": "act-foo", "name": "aws:xyz"},
-                         {"accountId": "act-bar", "name": "aws:zbr"}
-                     ],
+                     "items": [],
                  }})
 
         with pytest.raises(MissingSpotinstAccount):
-            resolve_account_id("fake-token", mock_info)
+            resolve_account_id("fake-token", "12345")
 
 
 def test_block_mappings():

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -35,11 +35,15 @@ def test_component_elastigroup_defaults(monkeypatch):
     mock_sg.return_value = "sg1"
     monkeypatch.setattr('senza.aws.resolve_security_group', mock_sg)
 
-    resolve_account_id = MagicMock()
-    resolve_account_id.return_value = 'act-12345abcdef'
-    monkeypatch.setattr('spotinst.components.elastigroup.resolve_account_id', resolve_account_id)
+    mock_resolve_account_id = MagicMock()
+    mock_resolve_account_id.return_value = 'act-12345abcdef'
+    monkeypatch.setattr('spotinst.components.elastigroup.resolve_account_id', mock_resolve_account_id)
 
-    result = component_elastigroup(definition, configuration, args, info, False, AccountArguments('reg1'))
+    mock_account_info = MagicMock()
+    mock_account_info.Region = "reg1"
+    mock_account_info.AccountID = "12345"
+
+    result = component_elastigroup(definition, configuration, args, info, False, mock_account_info)
 
     properties = result["Resources"]["eg1Config"]["Properties"]
     assert properties["accountId"] == 'act-12345abcdef'


### PR DESCRIPTION
Spotinst changed the API to support backend [matching for a given AWS account ID](https://api.spotinst.com/organization-accounts/get-accounts/)

This change makes the cloud account resolution more efficient and less fragile (no longer parsing the cloud account name).

This should also enable users to keep more user-friendly names in the Spotinst cloud accounts.