### PR TITLE
removed Config suffix from Elastigroup resource names

### DIFF
--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -64,7 +64,7 @@ def component_elastigroup(definition, configuration, args, info, force, account_
     extract_instance_profile(args, definition, configuration, elastigroup_config)
     # cfn definition
     access_token = _extract_spotinst_access_token(definition)
-    config_name = configuration["Name"] + "Config"
+    config_name = configuration["Name"]
     definition["Resources"][config_name] = {
         "Type": "Custom::elastigroup",
         "Properties": {

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -44,7 +44,7 @@ def test_component_elastigroup_defaults(monkeypatch):
 
     result = component_elastigroup(definition, configuration, args, info, False, mock_account_info)
 
-    properties = result["Resources"]["eg1Config"]["Properties"]
+    properties = result["Resources"]["eg1"]["Properties"]
     assert properties["accountId"] == 'act-12345abcdef'
     assert properties["group"]["capacity"] == {"target": 1, "minimum": 1, "maximum": 1}
     instance_types = properties["group"]["compute"]["instanceTypes"]


### PR DESCRIPTION
This shouldn't cause any surprises since the previous behavior was "mostly" to keep the explicit resource names.

It closes #534 

/cc @pc-alves @jmcs