### PR TITLE
added support for the TargetGroupARNs property in Elastigroups

### DIFF
--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -351,17 +351,25 @@ def extract_load_balancer_name(configuration, elastigroup_config: dict):
         if "ElasticLoadBalancerV2" in configuration:
             health_check_type = "TARGET_GROUP"
             load_balancer_refs = configuration.pop("ElasticLoadBalancerV2")
-            if isinstance(load_balancer_refs, str):
-                load_balancers.append({
-                    "arn": {"Ref": load_balancer_refs + 'TargetGroup'},
-                    "type": "TARGET_GROUP"
-                })
-            elif isinstance(load_balancer_refs, list):
-                for load_balancer_ref in load_balancer_refs:
+            custom_target_groups = configuration.pop("TargetGroupARNs", None)
+            if custom_target_groups:
+                for custom_target_group in custom_target_groups:
                     load_balancers.append({
-                        "arn": {"Ref": load_balancer_ref + "TargetGroup"},
+                        "arn": custom_target_group,
                         "type": "TARGET_GROUP"
                     })
+            else:
+                if isinstance(load_balancer_refs, str):
+                    load_balancers.append({
+                        "arn": {"Ref": load_balancer_refs + 'TargetGroup'},
+                        "type": "TARGET_GROUP"
+                    })
+                elif isinstance(load_balancer_refs, list):
+                    for load_balancer_ref in load_balancer_refs:
+                        load_balancers.append({
+                            "arn": {"Ref": load_balancer_ref + "TargetGroup"},
+                            "type": "TARGET_GROUP"
+                        })
 
         if len(load_balancers) > 0:
             launch_spec_config["loadBalancersConfig"] = {"loadBalancers": load_balancers}


### PR DESCRIPTION
The native AutoScalingGroup allowed a [subset of CloudFormation properties to be set directly](https://github.com/zalando-stups/senza/blob/98bcf0fe68cba1193d72744ba30d4f86445c261d/senza/components/auto_scaling_group.py#L17)

Some of the keys don't make sense/are not usable with Elastigroups: `TerminationPolicies` and `MetricsCollection`.

The `PlacementGroup` is supported by the Elastigroup and should be addressed separately.

This change adds support for the `TargetGroupARNs` property. When present, they will be set as the [Elastigroup's `loadBalancers`](https://api.spotinst.com/spotinst-api/elastigroup/amazon-web-services/create/).
The [default TargetGroup is still created by the `ElasticLoadBalancerV2` component](https://github.com/zalando-stups/senza/blob/98bcf0fe68cba1193d72744ba30d4f86445c261d/senza/components/elastic_load_balancer_v2.py#L147) for backward compatibility but not used/referred by the Elastigroup.

/cc @pc-alves @jmcs 