### PR TITLE
Fix zero instances for SuccessRequires in AutoScalingGroups

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -276,7 +276,7 @@ def normalize_asg_success(success):
     duration = "PT15M"
 
     # if it's falsy, return defaults
-    if not success:
+    if success is None:
         return [count, duration]
 
     # if it's int, use as instance count

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -762,7 +762,9 @@ def test_to_iso8601_duration():
 
 def test_normalize_asg_success():
     default = "PT15M"
+    assert normalize_asg_success(0) == ["0", default]
     assert normalize_asg_success(10) == ["10", default]
+    assert normalize_asg_success("0") == ["0", default]
     assert normalize_asg_success("10") == ["10", default]
     assert normalize_asg_success("1 within 4h5s") == ["1", "PT4H5S"]
     assert normalize_asg_success("4 within 30m") == ["4", "PT30M"]


### PR DESCRIPTION
When the `SuccessRequires` is 0 of int type, the check does not as expected, and returns `"1"` for the CloudFormation. When the `"0"` of str type is used, it works fine. Because `if 0` is false, while `if "0"` is true.

As a result, the formations with 0 expected instances in start fail to create when in the AWS, because it expects at least 1:

```
      AutoScaling:
        Minimum: 0
        Maximum: 1
        DesiredCapacity: 0
        SuccessRequires: 0     # <== fails
        SuccessRequires: "0"   # <== works
```


This fix makes the check more specific, and the only assumed "absent" value could be `None` here (despite this case is not mentioned in the tests at all, and not present anywhere in the code).

Therefore, the `0` int value goes to the actual check for `int` type, and is now handled properly.