### PR TITLE
trying to fix flaky test_invalid_definition

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def test_invalid_definition():
 
         result = runner.invoke(cli, ['print', 'myapp.yaml', '--region=aa-fakeregion-1', '123'], catch_exceptions=False)
 
-    assert 'Error: Invalid value for "DEFINITION"' in result.output
+    assert 'error: invalid value for "definition"' in result.output.lower()
 
 
 def test_file_not_found():


### PR DESCRIPTION
In Travis this test contains an upper case `DEFINITION`. CDP builds have a lower case `definition`.
The case should not be relevant to the semantics of the test.