### PR TITLE
fixed the user data encoding by using the proper base64

### DIFF
--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -315,8 +315,8 @@ def extract_user_data(configuration, elastigroup_config, info: dict, force, acco
         if not force and docker_image.registry:
             check_docker_image_exists(docker_image)
 
-        user_data = base64.urlsafe_b64encode(generate_user_data(taupage_config, account_info.Region).encode('utf-8'))
-        elastigroup_config["compute"]["launchSpecification"]["userData"] = user_data.decode('utf-8')
+        elastigroup_config["compute"]["launchSpecification"]["userData"] = \
+            {"Fn::Base64": generate_user_data(taupage_config, account_info.Region)}
 
 
 def extract_load_balancer_name(configuration, elastigroup_config: dict):

--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -2,7 +2,6 @@
 Functions to create Spotinst Elastigroups
 """
 
-import base64
 import sys
 
 import click

--- a/senza/patch.py
+++ b/senza/patch.py
@@ -107,7 +107,7 @@ def patch_elastigroup(group, properties, elastigroup_id, spotinst_account_data):
             if key == 'UserData':
                 if should_patch_user_data(val, current_properties[key]):
                     patched_user_data = patch_user_data(current_properties[key], val)
-                    encoded_user_data = base64.urlsafe_b64encode(patched_user_data.encode('utf-8')).decode('utf-8')
+                    encoded_user_data = base64.b64encode(patched_user_data.encode('utf-8')).decode('utf-8')
                     properties_to_patch[key] = encoded_user_data
             else:
                 if current_properties[key] != val:

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -43,10 +43,10 @@ def test_patch_elastigroup(monkeypatch):
 
     monkeypatch.setattr('senza.spotinst.components.elastigroup_api.patch_elastigroup', create_lc)
 
-    properties = {'ImageId': 'mynewimage', 'InstanceType': 'mynewinstancetyoe', 'UserData': {'source': 'newsource'}}
+    properties = {'ImageId': 'mynewimage', 'InstanceType': 'mynewinstancetyoe', 'UserData': {'source': 'newsource >'}}
     group = {'compute': {
             'launchSpecification': {
-                'userData': codecs.encode(b'#firstline\nsource: oldsource', 'base64').decode('utf-8'),
+                'userData': base64.b64encode('#firstline\nsource: oldsource\n'.encode('utf-8')).decode('utf-8'),
                 'imageId': 'myoldimage'
             },
             'instanceTypes': {
@@ -58,7 +58,7 @@ def test_patch_elastigroup(monkeypatch):
 
     assert changed
     assert new_lc['ImageId'] == 'mynewimage'
-    assert new_lc['UserData'] == base64.urlsafe_b64encode('#firstline\nsource: newsource\n'.encode('utf-8')).decode('utf-8')
+    assert new_lc['UserData'] == base64.b64encode('#firstline\nsource: newsource >\n'.encode('utf-8')).decode('utf-8')
     assert new_lc['InstanceType'] == 'mynewinstancetyoe'
 
 


### PR DESCRIPTION
The function `base64.urlsafe_b64encode()` would fail to properly encode the `>` character, as stated in #540 

That affected the Elastigroup creation whenever the `>` was present in the user data.

For the CloudFormation template the fix was to use the same deferred call to `Fn::Base64`, just [like for the native Auto Scaling Groups](https://github.com/zalando-stups/senza/blob/0b7c7cee8d7c4f1a2bc01c9cc2cad42171292d98/senza/components/taupage_auto_scaling_group.py#L144).

The patch command was changed to use the correct `base64.b64encode()` function.