### PR TITLE
change in the strategy to report instances

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -619,7 +619,7 @@ def test_instances(monkeypatch):
             instance.public_ip_address = '8.8.8.8'
             instance.private_ip_address = '10.0.0.1'
             instance.state = {'Name': 'Test-instance'}
-            instance.tags = [{'Key': 'aws:cloudformation:stack-name', 'Value': 'test-1'},
+            instance.tags = [{'Key': 'Name', 'Value': 'test-1'},
                              {'Key': 'aws:cloudformation:logical-id', 'Value': 'local-id-123'},
                              {'Key': 'StackName', 'Value': 'test'},
                              {'Key': 'StackVersion', 'Value': '1'}]


### PR DESCRIPTION
This small change seems to be enough to allow reporting instances managed by Elastigroups.

Only AWS can set `aws:` prefixed tags. Instances created by the Elastigroups don't have the `aws:cloudformation:stack-name` tag that was used to filter instances.

Pragmatically, I believe that the `Name` tag contains exactly the same information, although the guarantee that it was created by CloudFormation no longer exists.

If this new approach doesn't sound reasonable, please share the particular uses cases or assumptions where this change will break.

This also changed the instance state filtering to the server side for some micro optimization.

This updates #517 