### PR TITLE
Always add standard STUPS EC2 tags

### DIFF
--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -340,18 +340,53 @@ def test_standard_tags():
                             {"tagKey": "Name", "tagValue": "foo-bar"},
                             {"tagKey": "StackName", "tagValue": "foo"},
                             {"tagKey": "StackVersion", "tagValue": "bar"},
-                        ]},
+                        ]
+                    },
                 },
                 "name": "foo-bar",
             },
         },
-        {  # leave tags untouched
+        {  # add standard tags if custom tags specified
             "definition": {"Mappings": {"Senza": {"Info": {"StackName": "foo", "StackVersion": "bar"}}}},
-            "given_config": {"compute": {"launchSpecification": {"tags": "fake"}}},
+            "given_config": {"compute": {"launchSpecification": {
+                "tags": [{"tagKey": "some-key", "tagValue": "some-value"}]}}
+            },
             "expected_config": {
                 "compute": {
                     "launchSpecification": {
-                        "tags": "fake"},
+                        "tags": [
+                            {"tagKey": "some-key", "tagValue": "some-value"},
+                            {"tagKey": "Name", "tagValue": "foo-bar"},
+                            {"tagKey": "StackName", "tagValue": "foo"},
+                            {"tagKey": "StackVersion", "tagValue": "bar"},
+                        ]
+                    },
+                },
+                "name": "foo-bar",
+            },
+        },
+        {  # should not override standard tags
+            "definition": {"Mappings": {"Senza": {"Info": {"StackName": "foo", "StackVersion": "bar"}}}},
+            "given_config": {
+                "compute": {
+                    "launchSpecification": {
+                        "tags": [
+                            {"tagKey": "Name", "tagValue": "some-name"},
+                            {"tagKey": "StackName", "tagValue": "some-stack-version"},
+                            {"tagKey": "StackVersion", "tagValue": "some-stack-version"}
+                        ]
+                    }
+                }
+            },
+            "expected_config": {
+                "compute": {
+                    "launchSpecification": {
+                        "tags": [
+                            {"tagKey": "Name", "tagValue": "foo-bar"},
+                            {"tagKey": "StackName", "tagValue": "foo"},
+                            {"tagKey": "StackVersion", "tagValue": "bar"},
+                        ]
+                    },
                 },
                 "name": "foo-bar",
             },


### PR DESCRIPTION
This PR makes changes to the way standard STUPS tags specified within `ElastiGroup` component are handled:

* Standard tags are always added to the list of tags even in the presence of custom tags
* Any standard tags specified in configuration are overridden by values from Senza definition - I have never ever had to specify these tags manually, so please let me know if you think there's a valid use case when it might be useful to actually override tags and I will change the logic

