### PR TITLE
docker image tags tests fixes

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -828,7 +828,7 @@ def test_check_docker_image_exists():
             return_value=fake_token), patch(
             'senza.components.taupage_auto_scaling_group.pierone.api.image_exists',
             return_value=True), patch(
-                'senza.components.taupage_auto_scaling_group.pierone.api.get_image_tag',
+                'senza.components.taupage_auto_scaling_group.pierone.api.get_latest_tag',
                 return_value=pierone_image):
 
         check_docker_image_exists(build_image(from_registry_url='pierone'))
@@ -845,7 +845,7 @@ def test_check_docker_image_exists():
     with patch('senza.components.taupage_auto_scaling_group.click.secho') as output_function, patch(
             'senza.components.taupage_auto_scaling_group.docker_image_exists',
             return_value=True), patch(
-                'senza.components.taupage_auto_scaling_group.pierone.api.get_image_tag',
+                'senza.components.taupage_auto_scaling_group.pierone.api.get_latest_tag',
                 return_value=pierone_image):
 
         check_docker_image_exists(build_image(from_registry_url='opensource'))
@@ -856,7 +856,7 @@ def test_check_docker_image_exists():
     with patch('senza.components.taupage_auto_scaling_group.click.secho') as output_function, patch(
             'senza.components.taupage_auto_scaling_group.docker_image_exists',
             return_value=True), patch(
-                'senza.components.taupage_auto_scaling_group.pierone.api.get_image_tag',
+                'senza.components.taupage_auto_scaling_group.pierone.api.get_latest_tag',
                 return_value=None):
 
         check_docker_image_exists(build_image(from_registry_url='opensource'))


### PR DESCRIPTION
see https://github.com/zalando-stups/pierone-cli/pull/78 
there is no `get_image_tag` in api.py after above PR. 
Switched to get_latest_tag that does almost the same. 