### PR TITLE
LB health checks configurations. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -447,6 +447,14 @@ The WeightedDnsElasticLoadBalancer component supports the following configuratio
     The HTTP path to use for health checks, e.g. "/health". Must return 200.
 ``HealthCheckPort``
     Optional. Port used for the health check. Defaults to ``HTTPPort``.
+``HealthCheckIntervalSeconds``
+    Optional. The amount of time between health checks of an individual instance, in seconds. Defaults to ``10``.
+``HealthCheckTimeoutSeconds``
+    Optional. The amount of time to wait when receiving a response from the health check, in seconds. Defaults to ``5``.
+``HealthyThresholdCount``
+    Optional. The number of consecutive successful health checks that must occur before declaring an EC2 instance healthy. Defaults to ``2``.
+``UnhealthyThresholdCount``
+    Optional. The number of consecutive failed health checks that must occur before declaring an EC2 instance unhealthy. Defaults to ``2``.
 ``SecurityGroups``
     List of security groups to use for the ELB. The security groups must allow SSL traffic.
 ``MainDomain``
@@ -486,6 +494,14 @@ The WeightedDnsElasticLoadBalancerV2 component supports the following configurat
     The HTTP path to use for health checks, e.g. "/health". Must return 200.
 ``HealthCheckPort``
     Optional. Port used for the health check. Defaults to ``HTTPPort``.
+``HealthCheckIntervalSeconds``
+    Optional. The amount of time between health checks of an individual instance, in seconds. Defaults to ``10``.
+``HealthCheckTimeoutSeconds``
+    Optional. The amount of time to wait when receiving a response from the health check, in seconds. Defaults to ``5``.
+``HealthyThresholdCount``
+    Optional. The number of consecutive successful health checks that must occur before declaring an EC2 instance healthy. Defaults to ``2``.
+``UnhealthyThresholdCount``
+    Optional. The number of consecutive failed health checks that must occur before declaring an EC2 instance unhealthy. Defaults to ``2``.
 ``SecurityGroups``
     List of security groups to use for the ELBv2. The security groups must allow SSL traffic.
 ``MainDomain``

--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -21,6 +21,10 @@ SENZA_PROPERTIES = frozenset(
         "SecurityGroups",
         "SSLCertificateId",
         "Type",
+        'UnHealthyThresholdCount',
+        'HealthCheckIntervalSeconds',
+        'HealthCheckTimeoutSeconds',
+        'HealthyThresholdCount'
     ]
 )
 ALLOWED_HEALTH_CHECK_PROTOCOLS = frozenset(["HTTP", "HTTPS", "TCP", "UDP", "SSL"])
@@ -160,6 +164,11 @@ def component_elastic_load_balancer(
     else:
         health_check_path = ""
 
+    health_check_interval = configuration.get("HealthCheckIntervalSeconds") or '10'
+    health_check_timeout = configuration.get("HealthCheckTimeoutSeconds") or '5'
+    healthy_threshold_count = configuration.get("HealthyThresholdCount") or '2'
+    unhealthy_threshold_count = configuration.get("UnhealthyThresholdCount") or healthy_threshold_count
+
     health_check_port = (
         configuration.get("HealthCheckPort") or configuration["HTTPPort"]
     )
@@ -211,10 +220,10 @@ def component_elastic_load_balancer(
                 ]
             },
             "HealthCheck": {
-                "HealthyThreshold": "2",
-                "UnhealthyThreshold": "2",
-                "Interval": "10",
-                "Timeout": "5",
+                "HealthyThreshold": healthy_threshold_count,
+                "UnhealthyThreshold": unhealthy_threshold_count,
+                "Interval": health_check_interval,
+                "Timeout": health_check_timeout,
                 "Target": health_check_target,
             },
             "Listeners": listeners,


### PR DESCRIPTION
This PR adds health checks related settings to be configurable from `AppLoadBalancer` senza section. 
Found that we can set `HealthCheckGracePeriod` for AutoScalingGroup to avoid failing of long-starting apps, 
but still having these settings configurable would something nice to have. 