### PR TITLE
Add Cross Stack Policy to IAM Role

### DIFF
--- a/senza/components/elastic_load_balancer.py
+++ b/senza/components/elastic_load_balancer.py
@@ -62,7 +62,7 @@ def get_ssl_cert(subdomain, main_zone, ssl_cert, account_info: AccountArguments)
         # the priority is acm_certificate first and iam_certificate second
         certificates = (
             acm_certificates + iam_certificates
-        )  # type: List[Union[ACMCertificate, IAMServerCertificate]]
+        )  # type: List[Union[ACMCertificate, IAMServerCertificate]] # noqa: F821
         try:
             certificate = certificates[0]
             ssl_cert = certificate.arn

--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -15,7 +15,7 @@ from senza.components.taupage_auto_scaling_group import check_application_id, ch
     check_docker_image_exists, generate_user_data
 from senza.utils import ensure_keys, CROSS_STACK_POLICY_NAME
 from senza.spotinst import MissingSpotinstAccount
-from senza.manaus.iam import find_or_create_policy
+import senza.manaus.iam
 
 ELASTIGROUP_RESOURCE_TYPE = 'Custom::elastigroup'
 SPOTINST_LAMBDA_FORMATION_ARN = 'arn:aws:lambda:{}:178579023202:function:spotinst-cloudformation'
@@ -86,7 +86,7 @@ def create_cross_stack_policy_document():
 def find_or_create_cross_stack_policy():
     return senza.manaus.iam.find_or_create_policy(policy_name=CROSS_STACK_POLICY_NAME,
                                                   policy_document=create_cross_stack_policy_document(),
-                                                  description="Required permissions for EC2 instances created by " +
+                                                  description="Required permissions for EC2 instances created by "
                                                               "Spotinst to signal CloudFormation")
 
 

--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -13,8 +13,9 @@ from senza.aws import resolve_security_groups
 from senza.components.auto_scaling_group import normalize_network_threshold
 from senza.components.taupage_auto_scaling_group import check_application_id, check_application_version, \
     check_docker_image_exists, generate_user_data
-from senza.utils import ensure_keys
+from senza.utils import ensure_keys, CROSS_STACK_POLICY_NAME
 from senza.spotinst import MissingSpotinstAccount
+from senza.manaus.iam import find_or_create_policy
 
 ELASTIGROUP_RESOURCE_TYPE = 'Custom::elastigroup'
 SPOTINST_LAMBDA_FORMATION_ARN = 'arn:aws:lambda:{}:178579023202:function:spotinst-cloudformation'
@@ -26,6 +27,81 @@ ELASTIGROUP_DEFAULT_STRATEGY = {
     "fallbackToOd": True,
 }
 ELASTIGROUP_DEFAULT_PRODUCT = "Linux/UNIX"
+
+
+def get_instance_profile_from_definition(definition, elastigroup_config):
+    launch_spec = elastigroup_config["compute"]["launchSpecification"]
+
+    if "iamRole" not in launch_spec:
+        return None
+
+    if "name" in launch_spec["iamRole"]:
+        if isinstance(launch_spec["iamRole"]["name"], dict):
+            instance_profile_id = launch_spec["iamRole"]["name"]["Ref"]
+            if instance_profile_id in definition["Resources"]:
+                return definition["Resources"][instance_profile_id]
+
+    return None
+
+
+def get_instance_profile_role(instance_profile, definition):
+    roles = instance_profile["Roles"]
+    if isinstance(roles[0], dict):
+        role_id = roles[0]["Ref"]
+        role = definition["Resources"].get(role_id, None)
+        if role is None:
+            raise click.UsageError("Instance Profile references a Role that is not present in Resources")
+
+        if role["Type"] != "AWS::IAM::Role":
+            raise click.UsageError("Instance Profile Role references a Resource that is not of type 'AWS::IAM::Role'")
+
+        return role
+
+    return None
+
+
+def create_cross_stack_policy_document():
+    return {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "cloudformation:SignalResource",
+                    "cloudformation:DescribeStackResource"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+
+
+def find_or_create_cross_stack_policy():
+    return senza.manaus.iam.find_or_create_policy(policy_name=CROSS_STACK_POLICY_NAME,
+                                                  policy_document=create_cross_stack_policy_document(),
+                                                  description="Required permissions for EC2 instances created by " +
+                                                              "Spotinst to signal CloudFormation")
+
+
+def patch_cross_stack_policy(definition, elastigroup_config):
+    """
+    This function will make sure that the role used in the Instance Profile includes the Cross Stack API
+    requests policy, needed for Elastigroups to run as expected.
+    """
+    instance_profile = get_instance_profile_from_definition(definition, elastigroup_config)
+    if instance_profile is None:
+        return
+
+    instance_profile_role = get_instance_profile_role(instance_profile, definition)
+    if instance_profile_role is None:
+        return
+
+    cross_stack_policy_arn = find_or_create_cross_stack_policy()
+
+    role_properties = instance_profile_role["Properties"]
+    managed_policies_set = set(role_properties.get("ManagedPolicyArns", []))
+    managed_policies_set.add(cross_stack_policy_arn)
+    role_properties["ManagedPolicyArns"] = list(managed_policies_set)
 
 
 def component_elastigroup(definition, configuration, args, info, force, account_info):
@@ -62,6 +138,7 @@ def component_elastigroup(definition, configuration, args, info, force, account_
     extract_auto_scaling_rules(configuration, elastigroup_config)
     extract_block_mappings(configuration, elastigroup_config)
     extract_instance_profile(args, definition, configuration, elastigroup_config)
+    patch_cross_stack_policy(definition, elastigroup_config)
     # cfn definition
     access_token = _extract_spotinst_access_token(definition)
     config_name = configuration["Name"]

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -163,16 +163,6 @@ class IAM:
             yield certificate
 
 
-def get_policy_by_name(policy_name):
-    """
-    This function goes through all the policies in the AWS account and return the first one matching the policy_name
-    input parameter
-    """
-    iam = boto3.client("iam")
-
-    return _get_policy_by_name(policy_name, iam)
-
-
 def _get_policy_by_name(policy_name, iam_client):
     """
     This function goes through all the policies in the AWS account and return the first one matching the policy_name

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -184,9 +184,9 @@ def _get_policy_by_name(policy_name, iam_client):
 def find_or_create_policy(policy_name, policy_document, description):
     """
     This function will look for a policy name with `policy_name`.
-    If not found, it will create the policy using the provided `policy_document`.
+    If not found, it will create the policy using the provided `policy_name` and `policy_document`.
 
-    :return: Cross Stack Policy object
+    :return: Policy object
     """
     iam_client = boto3.client("iam")
 

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -170,7 +170,15 @@ def get_policy_by_name(policy_name):
     """
     iam = boto3.client("iam")
 
-    paginator = iam.get_paginator("list_policies")
+    return _get_policy_by_name(policy_name, iam)
+
+
+def _get_policy_by_name(policy_name, iam_client):
+    """
+    This function goes through all the policies in the AWS account and return the first one matching the policy_name
+    input parameter
+    """
+    paginator = iam_client.get_paginator("list_policies")
 
     page_iterator = paginator.paginate()
 
@@ -181,3 +189,24 @@ def get_policy_by_name(policy_name):
                     return policy
 
     return None
+
+
+def find_or_create_policy(policy_name, policy_document, description):
+    """
+    This function will look for a policy name with `policy_name`.
+    If not found, it will create the policy using the provided `policy_document`.
+
+    :return: Cross Stack Policy object
+    """
+    iam_client = boto3.client("iam")
+
+    policy = _get_policy_by_name(policy_name, iam_client)
+    if policy is None:
+        response = iam_client.create_policy(
+            PolicyName=policy_name,
+            PolicyDocument=policy_document,
+            Description=description
+        )
+        policy = response["Policy"]
+
+    return policy

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -161,3 +161,23 @@ class IAM:
                 continue
 
             yield certificate
+
+
+def get_policy_by_name(policy_name):
+    """
+    This function goes through all the policies in the AWS account and return the first one matching the policy_name
+    input parameter
+    """
+    iam = boto3.client("iam")
+
+    paginator = iam.get_paginator("list_policies")
+
+    page_iterator = paginator.paginate()
+
+    for page in page_iterator:
+        if "Policies" in page:
+            for policy in page["Policies"]:
+                if policy["PolicyName"] == policy_name:
+                    return policy
+
+    return None

--- a/senza/manaus/iam.py
+++ b/senza/manaus/iam.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional, Union
 
 import boto3
+import json
 from botocore.exceptions import ClientError
 
 from .boto_proxy import BotoClientProxy
@@ -194,7 +195,7 @@ def find_or_create_policy(policy_name, policy_document, description):
     if policy is None:
         response = iam_client.create_policy(
             PolicyName=policy_name,
-            PolicyDocument=policy_document,
+            PolicyDocument=json.dumps(policy_document),
             Description=description
         )
         policy = response["Policy"]

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -3,9 +3,12 @@ import re
 
 import boto3
 import botocore.exceptions
+# TODO :: WITHOUT THIS IMPORT, TEST test_template_helper_check_iam_role CANNOT MOCK click.confirm
 import click
 import clickclick
 from clickclick import Action
+# TODO :: WITHOUT THIS IMPORT, TESTS test_init, test_init_opt2 and test_init_opt5 FAIL DUE TO IMPORT ERROR
+from click import confirm
 from senza.aws import get_account_alias, get_account_id, get_security_group
 
 from ..manaus.boto_proxy import BotoClientProxy

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -167,6 +167,8 @@ def check_iam_role(application_id: str, bucket_name: str, region: str):
         ],
         "Version": "2008-10-17",
     }
+
+    create = False
     if not exists:
         create = confirm(
             "IAM role {} does not exist. "
@@ -181,10 +183,13 @@ def check_iam_role(application_id: str, bucket_name: str, region: str):
                 )
 
     update_policy = bucket_name is not None and (
-        not exists
-        or confirm(
-            "IAM role {} already exists. ".format(role_name)
-            + "Do you want Senza to overwrite the role policy?"
+        (not exists and create)
+        or (
+            exists
+            or confirm(
+                "IAM role {} already exists. ".format(role_name)
+                + "Do you want Senza to overwrite the role policy?"
+            )
         )
     )
     if update_policy:

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -236,7 +236,7 @@ def check_iam_role(application_id: str, bucket_name: str, region: str):
 def find_or_create_cross_stack_policy():
     return senza.manaus.iam.find_or_create_policy(policy_name=CROSS_STACK_POLICY_NAME,
                                                   policy_document=create_cross_stack_policy_document(),
-                                                  description="Required permissions for EC2 instances created by " +
+                                                  description="Required permissions for EC2 instances created by "
                                                               "Spotinst to signal CloudFormation")
 
 

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -240,6 +240,9 @@ def find_or_create_cross_stack_policy():
 
 
 def attach_cross_stack_policy(pre_existing_role, role_created, role_name, iam_client):
+    if not pre_existing_role and not role_created:
+        return
+
     cross_stack_policy_exists = False
     if pre_existing_role:
         cross_stack_policy_exists = check_cross_stack_policy(iam_client, role_name)

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -186,7 +186,7 @@ def check_iam_role(application_id: str, bucket_name: str, region: str):
         (not exists and create)
         or (
             exists
-            or confirm(
+            and confirm(
                 "IAM role {} already exists. ".format(role_name)
                 + "Do you want Senza to overwrite the role policy?"
             )

--- a/senza/templates/_helper.py
+++ b/senza/templates/_helper.py
@@ -221,8 +221,7 @@ def check_iam_role(application_id: str, bucket_name: str, region: str):
         )
     )
     if attach_mint_read_policy:
-        with Action("Updat"
-                    "ing IAM role policy of {}..".format(role_name)):
+        with Action("Updating IAM role policy of {}..".format(role_name)):
             mint_read_policy = create_mint_read_policy_document(application_id, bucket_name, region)
             iam.put_role_policy(
                 RoleName=role_name,

--- a/senza/utils.py
+++ b/senza/utils.py
@@ -6,6 +6,8 @@ the domain of any other module.
 import re
 import pystache
 
+CROSS_STACK_POLICY_NAME = "system-cf-notifications"
+
 
 def named_value(dictionary):
     """

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -12,7 +12,7 @@ from senza.components.elastigroup import (component_elastigroup, ELASTIGROUP_DEF
                                           ensure_default_product, fill_standard_tags, extract_subnets,
                                           extract_load_balancer_name, extract_public_ips,
                                           extract_image_id, extract_security_group_ids, extract_instance_types,
-                                          extract_instance_profile)
+                                          extract_instance_profile, patch_cross_stack_policy)
 
 
 def test_component_elastigroup_defaults(monkeypatch):
@@ -787,3 +787,138 @@ def test_extract_instance_profile(monkeypatch):
             got = test_case["given_config"]
             extract_instance_profile(MagicMock(), MagicMock(), test_case["input"], got)
             assert test_case["expected_config"] == got
+
+
+def test_patch_cross_stack_policy(monkeypatch):
+    test_cases = [
+        {   # No instance profile in definition
+            "elastigroup_config": {"compute": {"launchSpecification": {}}},
+            "definition": {},
+            "expected_output": {}
+        },
+        {   # Instance profile definition references a managed instance profile
+            "elastigroup_config": {"compute": {"launchSpecification": {"iamRole": {
+                "arn": "arn:aws:iam::12345667:instance-profile/foo"}}}},
+            "definition": {},
+            "expected_output": {}
+        },
+        {   # Instance profile Role definition references a managed role
+            "elastigroup_config": {"compute": {"launchSpecification": {"iamRole": {
+                "name": {"Ref": "my-instance-profile"}}}}},
+            "definition": {"Resources": {"my-instance-profile": {
+                "Type": "AWS::IAM::InstanceProfile",
+                "Properties": {"Path": "/", "Roles": ['a-managed-role']}}}},
+            "expected_output": {"Resources": {"my-instance-profile": {
+                "Type": "AWS::IAM::InstanceProfile",
+                "Properties": {"Path": "/", "Roles": ['a-managed-role']}}}}
+        },
+        {   # Policy not in policies list of role
+            "elastigroup_config": {"compute": {"launchSpecification": {"iamRole": {
+                "name": {"Ref": "my-instance-profile1"}}}}},
+            "definition": {"Resources": {
+                "my-instance-profile1": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role1"}]}
+                },
+                "my-role1": {
+                    "Type": "AWS::IAM::Role",
+                    "Properties": {}
+                }
+            }},
+            "expected_output": {"Resources": {
+                "my-instance-profile1": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role1"}]}
+                },
+                "my-role1": {
+                    "Type": "AWS::IAM::Role",
+                    "Properties": {"ManagedPolicyArns": ['arn:aws:iam::aws:policy/zed']}
+                }
+            }}
+        },
+        {   # Policy already in policies list of role
+            "elastigroup_config": {"compute": {"launchSpecification": {"iamRole": {
+                "name": {"Ref": "my-instance-profile2"}}}}},
+            "definition": {"Resources": {
+                "my-instance-profile2": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role2"}]}
+                },
+                "my-role2": {
+                    "Type": "AWS::IAM::Role",
+                    "Properties": {"ManagedPolicyArns": ['arn:aws:iam::aws:policy/zed']}
+                }
+            }},
+            "expected_output": {"Resources": {
+                "my-instance-profile2": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role2"}]}
+                },
+                "my-role2": {
+                    "Type": "AWS::IAM::Role",
+                    "Properties": {"ManagedPolicyArns": ['arn:aws:iam::aws:policy/zed']}
+                }
+            }}
+        }
+    ]
+
+    cross_stack_policy_mock = MagicMock()
+    cross_stack_policy_mock.return_value = {"PolicyName": "zed", "Arn": "arn:aws:iam::aws:policy/zed"}
+    monkeypatch.setattr("senza.manaus.iam.find_or_create_policy", cross_stack_policy_mock)
+
+    for test_case in test_cases:
+        definition = test_case["definition"]
+        patch_cross_stack_policy(definition, test_case["elastigroup_config"])
+
+        assert definition == test_case["expected_output"]
+
+def test_patch_cross_stack_policy_errors():
+    # Error case 1 :: Instance profile not in Resources
+    with pytest.raises(click.UsageError):
+        elastigroup_config = {"compute": {"launchSpecification": {"iamRole": {
+            "name": {"Ref": "my-instance-profile"}}}}}
+        definition = {"Resources": {}}
+
+        patch_cross_stack_policy(definition, elastigroup_config)
+
+    # Error case 2 :: Instance profile not of type AWS::IAM::InstanceProfile
+    with pytest.raises(click.UsageError):
+        elastigroup_config = {"compute": {"launchSpecification": {"iamRole": {
+            "name": {"Ref": "my-instance-profile"}}}}}
+        definition = {"Resources": {
+            "my-instance-profile": {
+                "Type": "AWS::IAM::SomeOtherResource",
+                "Properties": {"Path": "/", "Roles": [{"Ref": "my-role"}]}
+            }}}
+
+        patch_cross_stack_policy(definition, elastigroup_config)
+
+    # Error case 3 :: Instance profile Role not in Resources
+    with pytest.raises(click.UsageError):
+        elastigroup_config = {"compute": {"launchSpecification": {"iamRole": {
+            "name": {"Ref": "my-instance-profile"}}}}}
+        definition = {"Resources": {
+                "my-instance-profile": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role"}]}
+                }
+            }}
+
+        patch_cross_stack_policy(definition, elastigroup_config)
+
+    # Error case 4 :: Instance profile Role not of type AWS::IAM::Role
+    with pytest.raises(click.UsageError):
+        elastigroup_config = {"compute": {"launchSpecification": {"iamRole": {
+            "name": {"Ref": "my-instance-profile"}}}}}
+        definition = {"Resources": {
+                "my-instance-profile": {
+                    "Type": "AWS::IAM::InstanceProfile",
+                    "Properties": {"Path": "/", "Roles": [{"Ref": "my-role"}]}
+                },
+                "my-role": {
+                    "Type": "AWS::IAM::SomeOtherResource",
+                    "Properties": {"ManagedPolicyArns": ['arn:aws:iam::aws:policy/zed']}
+                }
+            }}
+
+        patch_cross_stack_policy(definition, elastigroup_config)

--- a/tests/test_manaus/test_acm.py
+++ b/tests/test_manaus/test_acm.py
@@ -218,7 +218,6 @@ def test_get_certificates(monkeypatch):
     assert len(certificates_net) == 1
     assert certificates_net[0].arn == 'arn:aws:acm:eu-west-1:cert2'
 
-    # TODO :: NOT MEANT TO BE MERGED!!! JUST HERE TO FIX THE TEST IN PYTHON 3.7
     m_client.describe_certificate.side_effect = [{'Certificate': CERT1},
                                                  {'Certificate': CERT3}]
     certificates_net = list(acm.get_certificates(valid_only=False,

--- a/tests/test_manaus/test_acm.py
+++ b/tests/test_manaus/test_acm.py
@@ -218,7 +218,9 @@ def test_get_certificates(monkeypatch):
     assert len(certificates_net) == 1
     assert certificates_net[0].arn == 'arn:aws:acm:eu-west-1:cert2'
 
-    m_client.describe_certificate.side_effect = [{'Certificate': CERT3}]
+    # TODO :: NOT MEANT TO BE MERGED!!! JUST HERE TO FIX THE TEST IN PYTHON 3.7
+    m_client.describe_certificate.side_effect = [{'Certificate': CERT1},
+                                                 {'Certificate': CERT3}]
     certificates_net = list(acm.get_certificates(valid_only=False,
                                                  domain_name="registry.opensource.zalan.do"))
     assert len(certificates_net) == 1

--- a/tests/test_manaus/test_iam.py
+++ b/tests/test_manaus/test_iam.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
-from senza.manaus.iam import IAM, IAMServerCertificate
+from senza.manaus.iam import IAM, IAMServerCertificate, find_or_create_policy
 
 IAM_CERT1 = {'CertificateBody': 'body',
              'CertificateChain': 'chain',
@@ -258,3 +258,65 @@ def test_equality(monkeypatch):
 
     assert certificate1 == certificate1_exp  # only the arn is compared
     assert certificate1 != certificate2
+
+
+def test_find_or_create_policy(monkeypatch):
+    policy_name = 'somePolicy'
+    policy_document = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "*"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    description = 'A general description of the policy'
+
+    iam = MagicMock()
+    iam.return_value = iam
+
+    paginator_mock = MagicMock()
+
+    monkeypatch.setattr('boto3.client', iam)
+
+    # Test case 1 :: Policy does not exist, policy is created
+    paginator_mock.paginate.return_value = [{'Policies': [{'PolicyName': 'foo', 'Arn': 'arn:aws:iam::aws:policy/foo'},
+                                                          {'PolicyName': 'bar', 'Arn': 'arn:aws:iam::aws:policy/bar'}]},
+                                            {'Policies': [{'PolicyName': 'zed', 'Arn': 'arn:aws:iam::aws:policy/zed'}]}]
+
+    iam.get_paginator.return_value = paginator_mock
+
+    iam.create_policy.return_value = {'Policy': {'PolicyName': policy_name,
+                                                 'Arn': 'arn:aws:iam::aws:policy/' + policy_name}}
+
+    policy = find_or_create_policy(policy_name, policy_document, description)
+
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 1
+    assert policy["PolicyName"] == policy_name
+
+    # Test case 2 :: Policy exists, policy creation is skipped
+    iam.reset_mock()
+
+    paginator_mock.paginate.return_value = [{'Policies': [{'PolicyName': 'foo', 'Arn': 'arn:aws:iam::aws:policy/foo'},
+                                                          {'PolicyName': 'bar', 'Arn': 'arn:aws:iam::aws:policy/bar'}]},
+                                            {
+                                                'Policies': [
+                                                    {'PolicyName': 'zed', 'Arn': 'arn:aws:iam::aws:policy/zed'},
+                                                    {'PolicyName': policy_name,
+                                                     'Arn': 'arn:aws:iam::aws:policy/' + policy_name}
+                                                ]
+                                            }
+                                            ]
+
+    iam.get_paginator.return_value = paginator_mock
+
+    policy = find_or_create_policy(policy_name, policy_document, description)
+
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 0
+    assert policy["PolicyName"] == policy_name

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -130,6 +130,16 @@ def test_attach_cross_stack_policy(monkeypatch):
     assert iam.get_role_policy.call_count == 0
     assert iam.attach_role_policy.call_count == 1
 
+    # Test case 3 :: role does not exist and was also not created
+    iam.reset_mock()
+
+    role_exists = False
+    role_created = False
+    attach_cross_stack_policy(role_exists, role_created, role_name, iam)
+
+    assert iam.get_role_policy.call_count == 0
+    assert iam.attach_role_policy.call_count == 0
+
 
 def test_choice_callable_default(monkeypatch):
     mock = MagicMock()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -8,7 +8,7 @@ from senza.templates.postgresapp import (ebs_optimized_supported,
                                          set_default_variables,
                                          generate_definition,
                                          get_latest_image)
-
+from senza.utils import CROSS_STACK_POLICY_NAME
 
 def test_template_helper_get_mint_bucket_name(monkeypatch):
     monkeypatch.setattr('senza.templates._helper.get_account_id', MagicMock(return_value=123))
@@ -94,6 +94,19 @@ def test_template_helper_check_iam_role(monkeypatch):
     put_role_policy_response = {'ResponseMetadata': 'some-metadata'}
     iam.put_role_policy.side_effect = [put_role_policy_response, put_role_policy_response]
 
+    paginator_mock = MagicMock()
+    paginator_mock.paginate.return_value = [{'Policies': [{'PolicyName': 'foo', 'Arn': 'arn:aws:iam::aws:policy/foo'},
+                                                          {'PolicyName': 'bar', 'Arn': 'arn:aws:iam::aws:policy/bar'}]},
+                                            {
+                                                'Policies': [
+                                                    {'PolicyName': 'zed', 'Arn': 'arn:aws:iam::aws:policy/zed'}
+                                                ]
+                                            }
+                                            ]
+    iam.get_paginator.return_value = paginator_mock
+
+    iam.create_policy.return_value = {'Policy': {'Arn': 'arn:aws:iam::aws:policy/' + CROSS_STACK_POLICY_NAME}}
+
     monkeypatch.setattr('boto3.client', iam)
 
     monkeypatch.setattr('click.confirm', MagicMock(return_value=True))
@@ -102,7 +115,10 @@ def test_template_helper_check_iam_role(monkeypatch):
 
     assert iam.get_role.call_count == 1
     assert iam.create_role.call_count == 1
-    assert iam.put_role_policy.call_count == 2
+    assert iam.put_role_policy.call_count == 1
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 1
+    assert iam.attach_role_policy.call_count == 1
 
     # Test case 2 :: skip create role -> create mint policy -> create cross stack policy
     iam.reset_mock()
@@ -122,7 +138,10 @@ def test_template_helper_check_iam_role(monkeypatch):
     assert iam.get_role.call_count == 1
     assert iam.create_role.call_count == 0
     assert iam.get_role_policy.call_count == 1
-    assert iam.put_role_policy.call_count == 2
+    assert iam.put_role_policy.call_count == 1
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 1
+    assert iam.attach_role_policy.call_count == 1
 
     # Test case 3 :: skip create role -> skip create mint policy -> create cross stack policy
     iam.reset_mock()
@@ -142,9 +161,12 @@ def test_template_helper_check_iam_role(monkeypatch):
     assert iam.get_role.call_count == 1
     assert iam.create_role.call_count == 0
     assert iam.get_role_policy.call_count == 1
-    assert iam.put_role_policy.call_count == 1
+    assert iam.put_role_policy.call_count == 0
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 1
+    assert iam.attach_role_policy.call_count == 1
 
-    # Test case 4 :: skip create role -> skip create mint policy -> skip create cross stack policy
+    # Test case 4 :: skip create role -> skip create mint policy -> cross stack policy already attached
     iam.reset_mock()
 
     get_role_response = {'Role': 'some-role'}
@@ -160,6 +182,41 @@ def test_template_helper_check_iam_role(monkeypatch):
     assert iam.create_role.call_count == 0
     assert iam.get_role_policy.call_count == 1
     assert iam.put_role_policy.call_count == 0
+    assert iam.get_paginator.call_count == 0
+    assert iam.create_policy.call_count == 0
+    assert iam.attach_role_policy.call_count == 0
+
+    # Test case 5 :: skip create role -> skip create mint policy -> cross stack policy not attached
+    iam.reset_mock()
+
+    get_role_response = {'Role': 'some-role'}
+    iam.get_role.side_effect = get_role_response
+
+    monkeypatch.setattr('click.confirm', MagicMock(return_value=False))
+
+    get_role_policy_error_response = {'Error': {'Code': 'Error getting the role policy'}}
+    iam.get_role_policy.side_effect = botocore.exceptions.ClientError(get_role_policy_error_response, 'get_role_policy')
+
+    paginator_mock.paginate.return_value = [{'Policies': [{'PolicyName': 'foo', 'Arn': 'arn:aws:iam::aws:policy/foo'},
+                                                          {'PolicyName': 'bar', 'Arn': 'arn:aws:iam::aws:policy/bar'}]},
+                                            {
+                                                'Policies': [
+                                                    {'PolicyName': 'zed', 'Arn': 'arn:aws:iam::aws:policy/zed'},
+                                                    {'PolicyName': CROSS_STACK_POLICY_NAME,
+                                                     'Arn': 'arn:aws:iam::aws:policy/' + CROSS_STACK_POLICY_NAME}
+                                                ]
+                                            }
+                                            ]
+
+    check_iam_role(application_id, bucket_name, region)
+
+    assert iam.get_role.call_count == 1
+    assert iam.create_role.call_count == 0
+    assert iam.get_role_policy.call_count == 1
+    assert iam.put_role_policy.call_count == 0
+    assert iam.get_paginator.call_count == 1
+    assert iam.create_policy.call_count == 0
+    assert iam.attach_role_policy.call_count == 1
 
 
 def test_choice_callable_default(monkeypatch):


### PR DESCRIPTION
On March 18, 2019, AWS introduced limitations to the scope of calls to stack level APIs, such as DescribeStackResources. These APIs are used by aws-cfn-bootstrap scripts, including cfn-init and cfn-hup, which are commonly used to provision EC2 instances created by CloudFormation.

This limitation has not been applied to accounts that are making cross stack requests, but this will only be like that until May 30, 2019. When this comes into effect, it will prevent Elastigroup deployments from functioning as expected.

The policy added in this PR is the one recommended by Spotinst [in their documentation](https://api.spotinst.com/provisioning-ci-cd-sdk/provisioning-tools/cloudformation/cfn-helper/).

This policy will be added when running the `init` command and when creating new Elastigroup stacks via `create` command. The policy will be added only if not found in the provided specification.

Current TODOs:

- [x] Fix issue with imports in tests
- [x] Patch policy in `create` command