### PR TITLE
add discovery of other standard STUPS AMIs for Elastigroups

### DIFF
--- a/senza/components/elastigroup.py
+++ b/senza/components/elastigroup.py
@@ -55,7 +55,7 @@ def component_elastigroup(definition, configuration, args, info, force, account_
     extract_user_data(configuration, elastigroup_config, info, force, account_info)
     extract_load_balancer_name(configuration, elastigroup_config)
     extract_public_ips(configuration, elastigroup_config)
-    extract_image_id(elastigroup_config)
+    extract_image_id(configuration, elastigroup_config)
     extract_security_group_ids(configuration, elastigroup_config, args)
     extract_instance_types(configuration, elastigroup_config)
     extract_autoscaling_capacity(configuration, elastigroup_config)
@@ -413,7 +413,7 @@ def extract_public_ips(configuration, elastigroup_config):
             ]
 
 
-def extract_image_id(elastigroup_config: dict):
+def extract_image_id(configuration, elastigroup_config: dict):
     """
     This function identifies whether a senza formatted AMI mapping is configured,
     if so it transforms it into a Spotinst Elastigroup AMI API configuration
@@ -422,7 +422,8 @@ def extract_image_id(elastigroup_config: dict):
     launch_spec_config = elastigroup_config["compute"]["launchSpecification"]
 
     if "imageId" not in launch_spec_config.keys():
-        launch_spec_config["imageId"] = {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "LatestTaupageImage"]}
+        image_key = configuration.get("Image", "LatestTaupageImage")
+        launch_spec_config["imageId"] = {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, image_key]}
 
 
 def extract_security_group_ids(configuration, elastigroup_config: dict, args):

--- a/tests/test_elastigroup.py
+++ b/tests/test_elastigroup.py
@@ -62,7 +62,8 @@ def test_component_elastigroup_defaults(monkeypatch):
     assert {'tagKey': 'StackName', 'tagValue': 'foobar'} in tags
     assert {'tagKey': 'StackVersion', 'tagValue': '0.1'} in tags
     assert properties["group"]["compute"]["product"] == ELASTIGROUP_DEFAULT_PRODUCT
-    assert properties["group"]["compute"]["subnetIds"] == {"Fn::FindInMap": ["ServerSubnets", {"Ref": "AWS::Region"}, "Subnets"]}
+    assert properties["group"]["compute"]["subnetIds"] == {
+        "Fn::FindInMap": ["ServerSubnets", {"Ref": "AWS::Region"}, "Subnets"]}
     assert properties["group"]["region"] == "reg1"
     assert properties["group"]["strategy"] == ELASTIGROUP_DEFAULT_STRATEGY
 
@@ -666,19 +667,28 @@ def test_public_ips():
 def test_extract_image_id():
     test_cases = [
         {  # default behavior - set latest taupage image
+            "input": {},
             "given_config": {},
             "expected_config": {"compute": {"launchSpecification": {
                 "imageId": {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "LatestTaupageImage"]}
             }}},
         },
         {  # leave imageId untouched
+            "input": {},
             "given_config": {"compute": {"launchSpecification": {"imageId": "fake-id"}}},
             "expected_config": {"compute": {"launchSpecification": {"imageId": "fake-id"}}},
         },
+        {  # use specified image from the Senza mapping
+            "input": {"Image": "Foo"},
+            "given_config": {},
+            "expected_config": {"compute": {"launchSpecification": {
+                "imageId": {"Fn::FindInMap": ["Images", {"Ref": "AWS::Region"}, "Foo"]}
+            }}},
+        }
     ]
     for test_case in test_cases:
         got = test_case["given_config"]
-        extract_image_id(got)
+        extract_image_id(test_case["input"], got)
         assert test_case["expected_config"] == got
 
 


### PR DESCRIPTION
This fixes #564 