### PR TITLE
overwrite minSize instances if 0

### DIFF
--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1964,7 +1964,7 @@ def respawn_instances(stack_ref, inplace, force, batch_size_percentage, region):
 @click.option(
     "--min_size",
     metavar="MIN_SIZE",
-    type=click.IntRange(0,100, clamp=True),
+    type=click.IntRange(0, 100, clamp=True),
     help="Define the MinSize to update the AutoScalingGroup.")
 @click.option(
     "-f", "--force", is_flag=True, help="Force scaling multiple stacks if needed"

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -2047,6 +2047,12 @@ def scale_auto_scaling_group(asg, asg_name, desired_capacity):
             act.ok("NO CHANGES")
         else:
             kwargs = {}
+            if group["MinSize"] == 0 and desired_capacity > group["MinSize"]:
+                kwargs["MinSize"] = desired_capacity
+                info(
+                    "Min instance number was set to 0. Overwriting it with "
+                    "desired capicity of {} to prevent unexpected downscaling.".format(desired_capacity)
+                )
             if desired_capacity < group["MinSize"]:
                 kwargs["MinSize"] = desired_capacity
             if desired_capacity > group["MaxSize"]:

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1962,7 +1962,7 @@ def respawn_instances(stack_ref, inplace, force, batch_size_percentage, region):
 @click.argument("stack_ref", nargs=-1)
 @click.argument("desired_capacity", type=click.IntRange(0, 100, clamp=True))
 @click.option(
-    "--min_size",
+    "--min-size",
     metavar="MIN_SIZE",
     type=click.IntRange(0, 100, clamp=True),
     help="Define the MinSize to update the AutoScalingGroup.")

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -2051,7 +2051,7 @@ def scale_auto_scaling_group(asg, asg_name, desired_capacity):
                 kwargs["MinSize"] = desired_capacity
                 info(
                     "Min instance number was set to 0. Overwriting it with "
-                    "desired capicity of {} to prevent unexpected downscaling.".format(desired_capacity)
+                    "desired capacity of {} to prevent unexpected downscaling.".format(desired_capacity)
                 )
             if desired_capacity < group["MinSize"]:
                 kwargs["MinSize"] = desired_capacity

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1984,7 +1984,7 @@ def scale(stack_ref, region, desired_capacity, force):
     asg = BotoClientProxy("autoscaling", region)
     for group in get_auto_scaling_groups_and_elasti_groups(stacks, region):
         if group["type"] == AUTO_SCALING_GROUP_TYPE:
-            scale_auto_scaling_group(asg, group["resource_id"], desired_capacity)
+            scale_auto_scaling_group(asg, group["resource_id"], desired_capacity, force)
         elif group["type"] == ELASTIGROUP_RESOURCE_TYPE:
             scale_elastigroup(
                 group["resource_id"], group["stack_name"], desired_capacity, region
@@ -2032,7 +2032,7 @@ def scale_elastigroup(elastigroup_id, stack_name, desired_capacity, region):
                 )
 
 
-def scale_auto_scaling_group(asg, asg_name, desired_capacity):
+def scale_auto_scaling_group(asg, asg_name, desired_capacity, force):
     """
     Commands to scale an AWS Auto Scaling Group
     """
@@ -2048,11 +2048,14 @@ def scale_auto_scaling_group(asg, asg_name, desired_capacity):
         else:
             kwargs = {}
             if group["MinSize"] == 0 and desired_capacity > group["MinSize"]:
-                kwargs["MinSize"] = desired_capacity
                 info(
-                    "Min instance number was set to 0. Overwriting it with "
-                    "desired capacity of {} to prevent unexpected downscaling.".format(desired_capacity)
+                    "Min instance number was set to 0 previously. Please "
+                    "overwrite the MinSize by using --force to overwrite the "
+                    "MinSize with the desired capacity of {} to prevent "
+                    "unexpected downscaling.".format(desired_capacity)
                 )
+                if force:
+                    kwargs["MinSize"] = desired_capacity
             if desired_capacity < group["MinSize"]:
                 kwargs["MinSize"] = desired_capacity
             if desired_capacity > group["MaxSize"]:

--- a/senza/cli.py
+++ b/senza/cli.py
@@ -1962,11 +1962,16 @@ def respawn_instances(stack_ref, inplace, force, batch_size_percentage, region):
 @click.argument("stack_ref", nargs=-1)
 @click.argument("desired_capacity", type=click.IntRange(0, 100, clamp=True))
 @click.option(
+    "--min_size",
+    metavar="MIN_SIZE",
+    type=click.IntRange(0,100, clamp=True),
+    help="Define the MinSize to update the AutoScalingGroup.")
+@click.option(
     "-f", "--force", is_flag=True, help="Force scaling multiple stacks if needed"
 )
 @region_option
 @stacktrace_visible_option
-def scale(stack_ref, region, desired_capacity, force):
+def scale(stack_ref, region, desired_capacity, min_size, force):
     """Scale Auto Scaling Group to desired capacity"""
 
     stack_refs = get_stack_refs(stack_ref)
@@ -1984,7 +1989,7 @@ def scale(stack_ref, region, desired_capacity, force):
     asg = BotoClientProxy("autoscaling", region)
     for group in get_auto_scaling_groups_and_elasti_groups(stacks, region):
         if group["type"] == AUTO_SCALING_GROUP_TYPE:
-            scale_auto_scaling_group(asg, group["resource_id"], desired_capacity, force)
+            scale_auto_scaling_group(asg, group["resource_id"], desired_capacity, min_size)
         elif group["type"] == ELASTIGROUP_RESOURCE_TYPE:
             scale_elastigroup(
                 group["resource_id"], group["stack_name"], desired_capacity, region
@@ -2032,7 +2037,7 @@ def scale_elastigroup(elastigroup_id, stack_name, desired_capacity, region):
                 )
 
 
-def scale_auto_scaling_group(asg, asg_name, desired_capacity, force):
+def scale_auto_scaling_group(asg, asg_name, desired_capacity, min_size):
     """
     Commands to scale an AWS Auto Scaling Group
     """
@@ -2047,15 +2052,18 @@ def scale_auto_scaling_group(asg, asg_name, desired_capacity, force):
             act.ok("NO CHANGES")
         else:
             kwargs = {}
-            if group["MinSize"] == 0 and desired_capacity > group["MinSize"]:
-                info(
-                    "Min instance number was set to 0 previously. Please "
-                    "overwrite the MinSize by using --force to overwrite the "
-                    "MinSize with the desired capacity of {} to prevent "
-                    "unexpected downscaling.".format(desired_capacity)
+            if min_size and desired_capacity < min_size:
+                fatal_error(
+                    "Desired capacity must be bigger than specified min_size value"
                 )
-                if force:
-                    kwargs["MinSize"] = desired_capacity
+            if not min_size and group["MinSize"] == 0:
+                info(
+                    "MinSize was set to 0 previously. This might result in "
+                    "unexpected downscaling of the stack. Please use --min_size "
+                    "to update the value."
+                )
+            if min_size:
+                kwargs["MinSize"] = min_size
             if desired_capacity < group["MinSize"]:
                 kwargs["MinSize"] = desired_capacity
             if desired_capacity > group["MaxSize"]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1802,7 +1802,7 @@ def test_scale_with_overwriting_zero_minsize(monkeypatch):
   runner = CliRunner()
   result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1'],
                          catch_exceptions=False)
-  assert 'Min instance number was set to 0. Overwriting it' in result.output
+  assert 'Min instance number was set to 0 previously' in result.output
 
 def test_wait(monkeypatch):
     cf = MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1789,52 +1789,52 @@ def test_scale_with_force_confirm(monkeypatch):
     assert 'Scaling myasg from 1 to 2 instances' in result.output
 
 def test_scale_with_overwriting_zero_minsize(monkeypatch):
-  boto3 = MagicMock()
-  boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
-                                                        'CreationTime': '2016-06-14'}]}
-  boto3.describe_stack_resources.return_value = {'StackResources': [
-    {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
-     'PhysicalResourceId': 'myasg',
-     'StackName': 'myapp-1'}]}
-  group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
-  boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
-  monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
-  runner = CliRunner()
-  result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '1'],
-                         catch_exceptions=False)
-  assert 'Scaling myasg from 0 to 2 instances' in result.output
+    boto3 = MagicMock()
+    boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
+                                                          'CreationTime': '2016-06-14'}]}
+    boto3.describe_stack_resources.return_value = {'StackResources': [
+      {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+       'PhysicalResourceId': 'myasg',
+       'StackName': 'myapp-1'}]}
+    group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
+    boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+    monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+    runner = CliRunner()
+    result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '1'],
+                           catch_exceptions=False)
+    assert 'Scaling myasg from 0 to 2 instances' in result.output
 
 def test_scale_desired_capacity_smaller_than_min_size(monkeypatch):
-  boto3 = MagicMock()
-  boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
-                                                        'CreationTime': '2016-06-14'}]}
-  boto3.describe_stack_resources.return_value = {'StackResources': [
-    {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
-     'PhysicalResourceId': 'myasg',
-     'StackName': 'myapp-1'}]}
-  group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
-  boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
-  monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
-  runner = CliRunner()
-  result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '4'],
-                         catch_exceptions=False)
-  assert 'Desired capacity must be bigger than specified min_size value' in result.output
+    boto3 = MagicMock()
+    boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
+                                                          'CreationTime': '2016-06-14'}]}
+    boto3.describe_stack_resources.return_value = {'StackResources': [
+      {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+       'PhysicalResourceId': 'myasg',
+       'StackName': 'myapp-1'}]}
+    group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
+    boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+    monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+    runner = CliRunner()
+    result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '4'],
+                           catch_exceptions=False)
+    assert 'Desired capacity must be bigger than specified min_size value' in result.output
 
 def test_scale_with_min_size_zero_without_specifying_it(monkeypatch):
-  boto3 = MagicMock()
-  boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
-                                                        'CreationTime': '2016-06-14'}]}
-  boto3.describe_stack_resources.return_value = {'StackResources': [
-    {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
-     'PhysicalResourceId': 'myasg',
-     'StackName': 'myapp-1'}]}
-  group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
-  boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
-  monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
-  runner = CliRunner()
-  result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1'],
-                         catch_exceptions=False)
-  assert 'MinSize was set to 0 previously' in result.output
+    boto3 = MagicMock()
+    boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
+                                                          'CreationTime': '2016-06-14'}]}
+    boto3.describe_stack_resources.return_value = {'StackResources': [
+      {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+       'PhysicalResourceId': 'myasg',
+       'StackName': 'myapp-1'}]}
+    group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
+    boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+    monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+    runner = CliRunner()
+    result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1'],
+                           catch_exceptions=False)
+    assert 'MinSize was set to 0 previously' in result.output
 
 def test_wait(monkeypatch):
     cf = MagicMock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1800,9 +1800,41 @@ def test_scale_with_overwriting_zero_minsize(monkeypatch):
   boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
   monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
   runner = CliRunner()
+  result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '1'],
+                         catch_exceptions=False)
+  assert 'Scaling myasg from 0 to 2 instances' in result.output
+
+def test_scale_desired_capacity_smaller_than_min_size(monkeypatch):
+  boto3 = MagicMock()
+  boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
+                                                        'CreationTime': '2016-06-14'}]}
+  boto3.describe_stack_resources.return_value = {'StackResources': [
+    {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+     'PhysicalResourceId': 'myasg',
+     'StackName': 'myapp-1'}]}
+  group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
+  boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+  monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+  runner = CliRunner()
+  result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1', '--min_size', '4'],
+                         catch_exceptions=False)
+  assert 'Desired capacity must be bigger than specified min_size value' in result.output
+
+def test_scale_with_min_size_zero_without_specifying_it(monkeypatch):
+  boto3 = MagicMock()
+  boto3.list_stacks.return_value = {'StackSummaries': [{'StackName': 'myapp-1',
+                                                        'CreationTime': '2016-06-14'}]}
+  boto3.describe_stack_resources.return_value = {'StackResources': [
+    {'ResourceType': 'AWS::AutoScaling::AutoScalingGroup',
+     'PhysicalResourceId': 'myasg',
+     'StackName': 'myapp-1'}]}
+  group = {'AutoScalingGroupName': 'myasg', 'DesiredCapacity': 0, 'MinSize': 0, 'MaxSize': 8}
+  boto3.describe_auto_scaling_groups.return_value = {'AutoScalingGroups': [group]}
+  monkeypatch.setattr('boto3.client', MagicMock(return_value=boto3))
+  runner = CliRunner()
   result = runner.invoke(cli, ['scale', 'myapp', '1', '2', '--region=aa-fakeregion-1'],
                          catch_exceptions=False)
-  assert 'Min instance number was set to 0 previously' in result.output
+  assert 'MinSize was set to 0 previously' in result.output
 
 def test_wait(monkeypatch):
     cf = MagicMock()


### PR DESCRIPTION
If the `MinSize` number of the autoscaling group was 0 and the user wants to scale up, we are overwriting `MinSize` with the new desired capacity. Users might not be aware of the fact that their stack might be downscaled after a time. 