### PR TITLE
Always set HttpTokens to optional

### DIFF
--- a/senza/components/auto_scaling_group.py
+++ b/senza/components/auto_scaling_group.py
@@ -11,7 +11,7 @@ from senza.components.iam_role import get_merged_policies
 from senza.utils import ensure_keys
 
 # properties evaluated by Senza
-SENZA_PROPERTIES = frozenset(["SecurityGroups", "Tags"])
+SENZA_PROPERTIES = frozenset(["SecurityGroups", "Tags", "MetadataOptions"])
 
 # additional CF properties which can be overwritten
 ADDITIONAL_PROPERTIES = {
@@ -78,6 +78,9 @@ def component_auto_scaling_group(
                 "AssociatePublicIpAddress", False
             ),
             "EbsOptimized": configuration.get("EbsOptimized", False),
+            "MetadataOptions": {
+                "HttpTokens": "optional"  # we want to still be able to use IMDSv1
+            },
         },
     }
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -743,6 +743,50 @@ def test_component_auto_scaling_group_optional_metric_type():
     assert "FooNetworkAlarmHigh" not in result["Resources"]
 
 
+def test_component_auto_scaling_hardcoded_metadata_http_tokens():
+    # we have MetadataOptions->HttpTokens 'optional' enforcement hardcoded
+    definition = {"Resources": {}}
+    configurations = [
+        {
+            'Name': 'Foo',
+            'InstanceType': 't2.micro',
+            'Image': 'foo',
+        },
+        {
+            'Name': 'Foo',
+            'InstanceType': 't2.micro',
+            'Image': 'foo',
+            'MetadataOptions': {
+                'HttpTokens': 'required',
+            }
+        },
+        {
+            'Name': 'Foo',
+            'InstanceType': 't2.micro',
+            'Image': 'foo',
+            'MetadataOptions': {
+                'HttpTokens': 'optional',
+                'HttpPutResponseHopLimit': 42,
+            }
+        },
+    ]
+
+    args = MagicMock()
+    args.region = "foo"
+    info = {
+        'StackName': 'FooStack',
+        'StackVersion': 'FooVersion'
+    }
+
+    for configuration in configurations:
+        result = component_auto_scaling_group(definition, configuration, args, info, False, MagicMock())
+
+        err_msg = "Failed configuration: {}".format(str(configuration))
+        assert result["Resources"]["FooConfig"]["Properties"]["MetadataOptions"]["HttpTokens"] == \
+            "optional", err_msg
+        assert len(result["Resources"]["FooConfig"]["Properties"]["MetadataOptions"]) == 1, err_msg
+
+
 def test_to_iso8601_duration():
     with pytest.raises(click.UsageError):
         to_iso8601_duration("")


### PR DESCRIPTION
This commit forces MetadataOptions->HttpTokens to always be set to 'optional' by senza, as we want to still be able to use IMDSv1, while base AMIs enforce v2 and ebs packer still doesn't allow this to be redefined.